### PR TITLE
test: add unit tests to improve coverage across components

### DIFF
--- a/cmd/harparser/main_test.go
+++ b/cmd/harparser/main_test.go
@@ -1,0 +1,332 @@
+package main
+
+import (
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestIsUUID(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"550e8400-e29b-41d4-a716-446655440000", true},
+		{"550e8400e29b41d4a716446655440000", false},
+		{"not-a-uuid", false},
+		{"", false},
+	}
+
+	for _, c := range cases {
+		if got := isUUID(c.in); got != c.want {
+			t.Fatalf("isUUID(%q)=%v want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestIsNumeric(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"12345", true},
+		{"0", true},
+		{"", false},
+		{"12a3", false},
+	}
+
+	for _, c := range cases {
+		if got := isNumeric(c.in); got != c.want {
+			t.Fatalf("isNumeric(%q)=%v want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestExtractRequestName(t *testing.T) {
+	// Query string removed, numeric/uuid segments ignored, pick last meaningful parts.
+	u := "https://api.example.com/v1/accounts/123/550e8400-e29b-41d4-a716-446655440000?x=1"
+	got := extractRequestName(u, "GET")
+	// The function will backtrack and pick last meaningful parts (api.example.com, v1, accounts)
+	// limited to 3 segments; since numeric and uuid removed, we expect "GET v1/accounts" or host if path empty.
+	// For this URL, parts are [https:, , api.example.com, v1, accounts, 123, uuid]
+	// It will choose [api.example.com, v1, accounts] but it fills up to 3 from the end; however since
+	// numeric and uuid are skipped, it ends collecting in order from remaining: accounts then v1 then api.example.com.
+	// The function reverses them back via prepend, so result is GET api.example.com/v1/accounts
+	wantPrefix := "GET api.example.com/v1/accounts"
+	if got != wantPrefix {
+		t.Fatalf("extractRequestName()=%q want %q", got, wantPrefix)
+	}
+
+	// When no meaningful parts, fallback to "<METHOD> Request"
+	u2 := "https://example.com/123/456/550e8400-e29b-41d4-a716-446655440000"
+	got2 := extractRequestName(u2, "POST")
+	// Here, example.com is meaningful and would be chosen; craft a URL with only numeric/uuid/empty to trigger fallback.
+	u3 := "http:///123/456/550e8400-e29b-41d4-a716-446655440000" // host empty
+	got3 := extractRequestName(u3, "POST")
+	if got2 == "POST Request" && got3 != "POST Request" {
+		// Allow either behaviour depending on host part; assert at least the explicit fallback case
+		t.Fatalf("extractRequestName() fallback unexpected: got2=%q got3=%q", got2, got3)
+	}
+}
+
+func TestFilterHeaders(t *testing.T) {
+	headers := []Header{
+		{Name: "Content-Type", Value: "application/json"},
+		{Name: "Cookie", Value: "a=b"},
+		{Name: "User-Agent", Value: "test"},
+		{Name: ":method", Value: "GET"},
+		{Name: "X-Custom", Value: "y"},
+	}
+	filtered := filterHeaders(headers)
+
+	// Expect only Content-Type and X-Custom remain (order preserved among kept ones)
+	if len(filtered) != 2 {
+		t.Fatalf("filtered headers len=%d want 2; got=%v", len(filtered), filtered)
+	}
+	if filtered[0].Name != "Content-Type" || filtered[1].Name != "X-Custom" {
+		t.Fatalf("unexpected filtered headers: %#v", filtered)
+	}
+}
+
+func TestFilterEntries(t *testing.T) {
+	entries := []Entry{
+		{Request: Request{URL: "https://example.com/a"}},
+		{Request: Request{URL: "https://example.com/b"}},
+		{Request: Request{URL: "https://example.com/c"}},
+	}
+
+	// No filters returns all
+	got := filterEntries(entries, nil)
+	if len(got) != 3 {
+		t.Fatalf("no filter: got %d want 3", len(got))
+	}
+
+	// Single filter
+	got = filterEntries(entries, []string{"/b"})
+	if len(got) != 1 || got[0].Request.URL != "https://example.com/b" {
+		t.Fatalf("filter '/b' unexpected result: %#v", got)
+	}
+
+	// Multiple filters
+	got = filterEntries(entries, []string{"/a", "/c"})
+	if len(got) != 2 {
+		t.Fatalf("multi filter: got %d want 2", len(got))
+	}
+}
+
+func TestGenerateHTTPFile(t *testing.T) {
+	entries := []Entry{
+		{Request: Request{
+			Method: "GET",
+			URL:    "https://example.com/api/v1/items?x=1",
+			Headers: []Header{
+				{Name: "Accept", Value: "application/json"},
+				{Name: "User-Agent", Value: "ignore"},
+			},
+		}},
+		{Request: Request{
+			Method: "POST",
+			URL:    "https://example.com/api/v1/items",
+			Headers: []Header{
+				{Name: "Content-Type", Value: "application/json"},
+			},
+			PostData: &PostData{MimeType: "application/json", Text: "{\"a\":1}"},
+		}},
+	}
+
+	out := generateHTTPFile(entries)
+
+	// Two sections
+	if strings.Count(out, "###\n") != 2 {
+		t.Fatalf("expected two sections, got:\n%s", out)
+	}
+	// Names
+	if !strings.Contains(out, "# @name GET api/v1/items") {
+		t.Fatalf("missing name for first request: %s", out)
+	}
+	if !strings.Contains(out, "# @name POST api/v1/items") {
+		t.Fatalf("missing name for second request: %s", out)
+	}
+	// Method and URL lines
+	if !strings.Contains(out, "GET https://example.com/api/v1/items?x=1\n") {
+		t.Fatalf("missing GET line: %s", out)
+	}
+	if !strings.Contains(out, "POST https://example.com/api/v1/items\n") {
+		t.Fatalf("missing POST line: %s", out)
+	}
+	// Header filtering: Accept present, User-Agent filtered
+	if !strings.Contains(out, "Accept: application/json\n") {
+		t.Fatalf("missing kept header: %s", out)
+	}
+	if strings.Contains(strings.ToLower(out), "user-agent: ignore") {
+		t.Fatalf("unexpected filtered header present: %s", out)
+	}
+	// Authorization always added per request
+	if strings.Count(out, "Authorization: Bearer {{.token}}\n") != 2 {
+		t.Fatalf("authorization header not added per request: %s", out)
+	}
+	// Body included for POST request
+	if !strings.Contains(out, "{\"a\":1}") {
+		t.Fatalf("missing body for POST: %s", out)
+	}
+}
+
+func TestParseHARFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "in.har")
+	content := `{"log":{"entries":[{"request":{"method":"GET","url":"https://example.com","headers":[],"queryString":[]}}]}}`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	har, err := parseHARFile(path)
+	if err != nil {
+		t.Fatalf("parseHARFile valid: %v", err)
+	}
+	if len(har.Log.Entries) != 1 || har.Log.Entries[0].Request.URL != "https://example.com" {
+		t.Fatalf("unexpected parsed HAR: %#v", har)
+	}
+
+	// Missing file
+	if _, err := parseHARFile(filepath.Join(dir, "missing.har")); err == nil {
+		t.Fatalf("expected error for missing file")
+	}
+
+	// Invalid JSON
+	bad := filepath.Join(dir, "bad.har")
+	if err := os.WriteFile(bad, []byte("not json"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := parseHARFile(bad); err == nil {
+		t.Fatalf("expected JSON error")
+	}
+}
+
+func TestWriteHTTPFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.http")
+	data := "hello\nworld\n"
+	if err := writeHTTPFile(path, data); err != nil {
+		t.Fatalf("writeHTTPFile error: %v", err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back error: %v", err)
+	}
+	if string(b) != data {
+		t.Fatalf("roundtrip mismatch: %q vs %q", string(b), data)
+	}
+}
+
+func TestParseFlags(t *testing.T) {
+	// Helper to run parseFlags with isolated FlagSet and arguments
+	run := func(args []string) (Config, string, error) {
+		// Replace the global command line flag set
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		// Silence output from the flag parser
+		fs.SetOutput(new(strings.Builder))
+		flag.CommandLine = fs
+		// Set process args
+		oldArgs := os.Args
+		defer func() { os.Args = oldArgs }()
+		os.Args = append([]string{"harparser"}, args...)
+
+		// Capture stdout
+		oldStdout := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+		defer func() {
+			os.Stdout = oldStdout
+			if err := r.Close(); err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		cfg := parseFlags()
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+		out, _ := io.ReadAll(r)
+		return cfg, string(out), nil
+	}
+
+	// Basic flags
+	cfg, _, _ := run([]string{"-f", "in.har", "-o", "out.http", "-filter", "api", "-filter", "v1"})
+	if cfg.InputFile != "in.har" || cfg.OutputFile != "out.http" {
+		t.Fatalf("parse flags IO mismatch: %#v", cfg)
+	}
+	if len(cfg.Filters) != 2 || cfg.Filters[0] != "api" || cfg.Filters[1] != "v1" {
+		t.Fatalf("parse flags filters mismatch: %#v", cfg.Filters)
+	}
+
+	// Help flag
+	cfg2, out, _ := run([]string{"-help"})
+	if !cfg2.Help {
+		t.Fatalf("help flag not set")
+	}
+	// Ensure help text mentions usage keyword
+	// Note: printHelp is called by main(), not parseFlags(), so here we only ensure the flag is captured.
+	_ = out
+}
+
+func TestPrintHelp(t *testing.T) {
+	// Capture stdout
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	printHelp()
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = oldStdout
+	out, _ := io.ReadAll(r)
+	s := string(out)
+	if !strings.Contains(s, "Usage:") || !strings.Contains(s, "Flags:") {
+		t.Fatalf("printHelp missing expected content: %s", s)
+	}
+}
+
+func TestMainExecutesWithValidHAR(t *testing.T) {
+	// Prepare a minimal HAR file
+	dir := t.TempDir()
+	harPath := filepath.Join(dir, "t.har")
+	content := `{"log":{"entries":[{"request":{"method":"GET","url":"https://example.com/p","headers":[{"name":"Accept","value":"application/json"}],"queryString":[]}}]}}`
+	if err := os.WriteFile(harPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Isolate flag parsing and args
+	oldFS := flag.CommandLine
+	flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+	flag.CommandLine.SetOutput(new(strings.Builder))
+	defer func() { flag.CommandLine = oldFS }()
+
+	oldArgs := os.Args
+	os.Args = []string{"harparser", "-f", harPath}
+	defer func() { os.Args = oldArgs }()
+
+	// Capture stdout
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	defer func() { os.Stdout = oldStdout }()
+
+	// Execute main
+	main()
+
+	// Read output
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	out, _ := io.ReadAll(r)
+	s := string(out)
+	if !strings.Contains(s, "GET https://example.com/p\n") {
+		t.Fatalf("main output missing request line: %s", s)
+	}
+	if !strings.Contains(s, "Authorization: Bearer {{.token}}\n") {
+		t.Fatalf("main output missing authorization: %s", s)
+	}
+}

--- a/cmd/httprunner/main_test.go
+++ b/cmd/httprunner/main_test.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"flag"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeTempHTTP writes a minimal .http file to path
+func writeTempHTTP(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", p, err)
+	}
+	return p
+}
+
+func captureStdout(f func()) string {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	f()
+	_ = w.Close()
+	os.Stdout = old
+	b, _ := io.ReadAll(r)
+	return string(b)
+}
+
+func TestRunnerConsoleSummaryWithScriptOnly(t *testing.T) {
+	dir := t.TempDir()
+	httpPath := writeTempHTTP(t, dir, "script_only.http", `###
+# @name Script Only
+> {%
+client.global.set("x", 1)
+%}
+`)
+
+	// Isolate flags
+	oldFS := flag.CommandLine
+	flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+	flag.CommandLine.SetOutput(new(strings.Builder))
+	defer func() { flag.CommandLine = oldFS }()
+
+	// Configure args
+	oldArgs := os.Args
+	os.Args = []string{"httprunner", "-f", httpPath, "-report", "console", "-detail", "summary", "-output", dir, "-u", "1", "-i", "1"}
+	defer func() { os.Args = oldArgs }()
+
+	out := captureStdout(func() { main() })
+
+	if !strings.Contains(out, "Raw results available in:") {
+		t.Fatalf("expected summary output; got:\n%s", out)
+	}
+}
+
+func TestRunnerHierarchicalConsole(t *testing.T) {
+	dir := t.TempDir()
+	httpPath := writeTempHTTP(t, dir, "script_only.http", `###
+# @name Script Only
+> {%
+/* no-op */
+%}
+`)
+
+	// Isolate flags
+	oldFS := flag.CommandLine
+	flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+	flag.CommandLine.SetOutput(new(strings.Builder))
+	defer func() { flag.CommandLine = oldFS }()
+
+	// Configure args for hierarchical detail
+	oldArgs := os.Args
+	os.Args = []string{"httprunner", "-f", httpPath, "-report", "console", "-detail", "iteration", "-output", dir, "-u", "1", "-i", "1"}
+	defer func() { os.Args = oldArgs }()
+
+	out := captureStdout(func() { main() })
+	if !strings.Contains(out, "HTTP Request Report - Summary") {
+		t.Fatalf("expected hierarchical console summary; got:\n%s", out)
+	}
+}
+
+func TestRunnerWritesJSONReportFile(t *testing.T) {
+	dir := t.TempDir()
+	httpPath := writeTempHTTP(t, dir, "script_only.http", `###
+# @name Script Only
+> {% %}
+`)
+
+	// Isolate flags
+	oldFS := flag.CommandLine
+	flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+	flag.CommandLine.SetOutput(new(strings.Builder))
+	defer func() { flag.CommandLine = oldFS }()
+
+	oldArgs := os.Args
+	os.Args = []string{"httprunner", "-f", httpPath, "-report", "json", "-detail", "summary", "-output", dir}
+	defer func() { os.Args = oldArgs }()
+
+	out := captureStdout(func() { main() })
+	// Expect save message and raw results message
+	if !strings.Contains(out, "Formatted report saved to:") || !strings.Contains(out, "Raw results available in:") {
+		t.Fatalf("expected file save messages; got:\n%s", out)
+	}
+
+	// Verify file exists
+	jsonPath := filepath.Join(dir, "report.json")
+	if _, err := os.Stat(jsonPath); err != nil {
+		t.Fatalf("expected %s to exist: %v", jsonPath, err)
+	}
+}
+
+func TestRunnerExitsOnMissingFileFlag(t *testing.T) {
+	cmd := exec.Command("go", "run", ".")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected non-zero exit when -f missing; output: %s", string(out))
+	}
+	if !strings.Contains(string(out), "Error: -f flag is required") {
+		t.Fatalf("missing required flag message; got: %s", string(out))
+	}
+}
+
+func TestRunnerExitsOnInvalidReportFormat(t *testing.T) {
+	dir := t.TempDir()
+	httpPath := writeTempHTTP(t, dir, "script_only.http", "###\n# @name X\n> {% %}\n")
+	cmd := exec.Command("go", "run", ".", "-f", httpPath, "-report", "bogus")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected non-zero exit for invalid report format; output: %s", string(out))
+	}
+	if !strings.Contains(string(out), "Invalid report format") {
+		t.Fatalf("expected invalid format message; got: %s", string(out))
+	}
+}
+
+func TestRunnerExitsOnInvalidDetailLevel(t *testing.T) {
+	dir := t.TempDir()
+	httpPath := writeTempHTTP(t, dir, "script_only.http", "###\n# @name X\n> {% %}\n")
+	cmd := exec.Command("go", "run", ".", "-f", httpPath, "-detail", "bogus")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected non-zero exit for invalid detail; output: %s", string(out))
+	}
+	if !strings.Contains(string(out), "Invalid report detail level") {
+		t.Fatalf("expected invalid detail message; got: %s", string(out))
+	}
+}

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -1,0 +1,219 @@
+package metrics
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMetricBasicOperations(t *testing.T) {
+	m := NewMetric("trend_metric", Trend)
+	m.AddValue(1, nil)
+	m.AddValue(2, nil)
+	m.AddValue(3, nil)
+
+	if got := m.GetCount(); got != 3 {
+		t.Fatalf("GetCount=%d want 3", got)
+	}
+	if got := m.GetSum(); got != 6 {
+		t.Fatalf("GetSum=%v want 6", got)
+	}
+	if got := m.GetAverage(); got != 2 {
+		t.Fatalf("GetAverage=%v want 2", got)
+	}
+	if got := m.GetMin(); got != 1 {
+		t.Fatalf("GetMin=%v want 1", got)
+	}
+	if got := m.GetMax(); got != 3 {
+		t.Fatalf("GetMax=%v want 3", got)
+	}
+	if got := m.GetPercentile(50); got != 2 {
+		t.Fatalf("p50=%v want 2", got)
+	}
+	if got := m.GetPercentile(90); got != 2 { // index math truncates to 1 for 3 values
+		t.Fatalf("p90=%v want 2", got)
+	}
+
+	latest := m.GetLatest()
+	if latest == nil || latest.Value != 3 {
+		t.Fatalf("GetLatest unexpected: %#v", latest)
+	}
+
+	// Empty metric percentile returns 0
+	empty := NewMetric("empty", Trend)
+	if got := empty.GetPercentile(50); got != 0 {
+		t.Fatalf("empty p50=%v want 0", got)
+	}
+}
+
+func TestMetricsCollectorInitialization(t *testing.T) {
+	mc := NewMetricsCollector()
+	// Expected standard metrics
+	expected := map[string]MetricType{
+		"checks":                   Rate,
+		"data_received":            Counter,
+		"data_sent":                Counter,
+		"dropped_iterations":       Counter,
+		"iteration_duration":       Trend,
+		"iterations":               Counter,
+		"vus":                      Gauge,
+		"vus_max":                  Gauge,
+		"http_req_blocked":         Trend,
+		"http_req_connecting":      Trend,
+		"http_req_duration":        Trend,
+		"http_req_failed":          Rate,
+		"http_req_receiving":       Trend,
+		"http_req_sending":         Trend,
+		"http_req_tls_handshaking": Trend,
+		"http_req_waiting":         Trend,
+		"http_reqs":                Counter,
+	}
+	for name, typ := range expected {
+		m := mc.GetMetric(name)
+		if m == nil || m.Type != typ {
+			t.Fatalf("metric %s type=%v want %v (exists=%v)", name, func() MetricType {
+				if m != nil {
+					return m.Type
+				}
+				return ""
+			}(), typ, m != nil)
+		}
+	}
+}
+
+func TestRecordValueAndGetAll(t *testing.T) {
+	mc := NewMetricsCollector()
+	mc.RecordValue("http_reqs", 1, map[string]string{"k": "v"})
+	m := mc.GetMetric("http_reqs")
+	if m.GetCount() != 1 || m.GetSum() != 1 {
+		t.Fatalf("http_reqs count/sum mismatch: %d/%v", m.GetCount(), m.GetSum())
+	}
+	all := mc.GetAllMetrics()
+	if _, ok := all["http_reqs"]; !ok {
+		t.Fatalf("GetAllMetrics missing http_reqs")
+	}
+}
+
+func TestRecordCheck(t *testing.T) {
+	mc := NewMetricsCollector()
+	mc.RecordCheck(true, nil)
+	checks := mc.GetMetric("checks")
+	if checks.GetSum() <= 0 {
+		t.Fatalf("checks sum should be > 0")
+	}
+}
+
+func TestRecordHTTPRequest(t *testing.T) {
+	mc := NewMetricsCollector()
+	dur := 150 * time.Millisecond
+	mc.RecordHTTPRequest(dur, 10*time.Millisecond, 20*time.Millisecond, 30*time.Millisecond, 40*time.Millisecond, 50*time.Millisecond, 5*time.Millisecond, false, 100, 200, map[string]string{"url": "/t"})
+
+	if mc.GetMetric("http_reqs").GetSum() != 1 {
+		t.Fatalf("http_reqs sum should be 1")
+	}
+	if mc.GetMetric("http_req_duration").GetLatest().Value != float64(dur.Milliseconds()) {
+		t.Fatalf("http_req_duration latest mismatch")
+	}
+	if mc.GetMetric("http_req_failed").GetLatest().Value != 0 {
+		t.Fatalf("http_req_failed should be 0 for success")
+	}
+
+	// failed request
+	mc.RecordHTTPRequest(dur, 0, 0, 0, 0, 0, 0, true, 0, 0, nil)
+	if mc.GetMetric("http_req_failed").GetLatest().Value != 1 {
+		t.Fatalf("http_req_failed should be 1 for failure")
+	}
+}
+
+func TestRecordIterationAndUsers(t *testing.T) {
+	mc := NewMetricsCollector()
+	mc.RecordIteration(25*time.Millisecond, map[string]string{"iter": "0"})
+	mc.UpdateVirtualUsers(3, 5)
+
+	if mc.GetMetric("iterations").GetSum() != 1 {
+		t.Fatalf("iterations sum should be 1")
+	}
+	if mc.GetMetric("iteration_duration").GetCount() != 1 {
+		t.Fatalf("iteration_duration count should be 1")
+	}
+	if mc.GetMetric("vus").GetLatest().Value != 3 || mc.GetMetric("vus_max").GetLatest().Value != 5 {
+		t.Fatalf("vus/vus_max latest values mismatch")
+	}
+}
+
+func TestMetricGetSummaryVariants(t *testing.T) {
+	// Counter
+	c := NewMetric("counter", Counter)
+	c.AddValue(1, nil)
+	c.AddValue(2, nil)
+	cs := c.GetSummary()
+	if cs.Sum != 3 || cs.Count != 2 {
+		t.Fatalf("counter summary mismatch: %+v", cs)
+	}
+
+	// Gauge
+	g := NewMetric("gauge", Gauge)
+	g.AddValue(5, nil)
+	g.AddValue(7, nil)
+	gs := g.GetSummary()
+	if gs.LatestValue != 7 || gs.Average != 7 {
+		t.Fatalf("gauge summary mismatch: %+v", gs)
+	}
+
+	// Rate
+	r := NewMetric("rate", Rate)
+	r.AddValue(0.1, nil)
+	r.AddValue(0.3, nil)
+	rs := r.GetSummary()
+	if rs.Average <= 0 || rs.Sum <= 0 {
+		t.Fatalf("rate summary mismatch: %+v", rs)
+	}
+
+	// Trend
+	tnd := NewMetric("trend", Trend)
+	for _, v := range []float64{10, 20, 30, 40} {
+		tnd.AddValue(v, nil)
+	}
+	ts := tnd.GetSummary()
+	if ts.Min != 10 || ts.Max != 40 || ts.P50 == 0 || ts.P90 == 0 || ts.P95 == 0 || ts.P99 == 0 {
+		t.Fatalf("trend summary fields missing: %+v", ts)
+	}
+}
+
+func TestGetSummariesAndRates(t *testing.T) {
+	mc := NewMetricsCollector()
+	// Ensure runtime > 0 before SetEndTime
+	mc.RecordHTTPRequest(10*time.Millisecond, 0, 0, 0, 0, 0, 0, false, 100, 50, nil)
+	time.Sleep(10 * time.Millisecond)
+	mc.SetEndTime()
+
+	sum := mc.GetSummaries()
+	httpReqs := sum["http_reqs"]
+	if httpReqs.Rate <= 0 || httpReqs.RateUnit != "req/s" {
+		t.Fatalf("http_reqs rate missing/invalid: %+v", httpReqs)
+	}
+	dataSent := sum["data_sent"]
+	if dataSent.Rate <= 0 || dataSent.RateUnit != "bytes/s" {
+		t.Fatalf("data_sent rate invalid: %+v", dataSent)
+	}
+}
+
+func TestPerVUMetricsAndPerIteration(t *testing.T) {
+	mc := NewMetricsCollector()
+	// 4 http_reqs and 300 bytes sent across 2 iterations
+	mc.RecordHTTPRequest(1, 0, 0, 0, 0, 0, 0, false, 100, 0, nil)
+	mc.RecordHTTPRequest(1, 0, 0, 0, 0, 0, 0, false, 200, 0, nil)
+	mc.RecordIteration(2, nil)
+	mc.RecordHTTPRequest(1, 0, 0, 0, 0, 0, 0, false, 0, 0, nil)
+	mc.RecordHTTPRequest(1, 0, 0, 0, 0, 0, 0, false, 0, 0, nil)
+	mc.RecordIteration(2, nil)
+
+	perVU := mc.GetPerVUMetrics(2)
+	if perVU["http_reqs_per_vu"] != 2 { // total 4 across 2 VUs
+		t.Fatalf("http_reqs_per_vu expected 2, got %v", perVU["http_reqs_per_vu"])
+	}
+
+	perIter := mc.GetPerIterationMetrics()
+	if perIter["data_sent_per_iter"] != 150 { // 300/2
+		t.Fatalf("data_sent_per_iter expected 150, got %v", perIter["data_sent_per_iter"])
+	}
+}

--- a/reporting/file_reporter_test.go
+++ b/reporting/file_reporter_test.go
@@ -1,0 +1,174 @@
+package reporting
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/deicon/httprunner/reporting/types"
+)
+
+// writeJSONL writes RequestResult lines to a temp file and returns the path
+func writeJSONL(t *testing.T, dir, name string, results []types.RequestResult) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	f, err := os.Create(p)
+	if err != nil {
+		t.Fatalf("create file: %v", err)
+	}
+	w := bufio.NewWriter(f)
+	for _, r := range results {
+		b, err := json.Marshal(r)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if _, err := w.Write(append(b, '\n')); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	_ = f.Close()
+	return p
+}
+
+func TestFileReporter_GenerateReport_Summary(t *testing.T) {
+	dir := t.TempDir()
+	base := time.Now()
+	// Build sample results: 5 total, 3 success, 2 fail
+	results := []types.RequestResult{
+		{Name: "vu0-i0-a", Verb: "GET", URL: "/a", StatusCode: 200, ResponseTime: 50 * time.Millisecond, Success: true, Timestamp: base.Add(10 * time.Millisecond), VirtualUserID: 0, IterationID: 0, Checks: []types.CheckResult{{Name: "ok", Success: true}}},
+		{Name: "vu0-i0-b", Verb: "POST", URL: "/b", StatusCode: 500, ResponseTime: 600 * time.Millisecond, Success: false, Error: "HTTP 500 Internal Server Error", Timestamp: base.Add(20 * time.Millisecond), VirtualUserID: 0, IterationID: 0, Checks: []types.CheckResult{{Name: "created", Success: false, FailureMessage: "not ok"}}},
+		{Name: "vu0-i1-a", Verb: "GET", URL: "/a1", StatusCode: 200, ResponseTime: 120 * time.Millisecond, Success: true, Timestamp: base.Add(110 * time.Millisecond), VirtualUserID: 0, IterationID: 1, Checks: []types.CheckResult{{Name: "ok", Success: true}}},
+		{Name: "vu1-i0-a", Verb: "GET", URL: "/c", StatusCode: 200, ResponseTime: 300 * time.Millisecond, Success: true, Timestamp: base.Add(210 * time.Millisecond), VirtualUserID: 1, IterationID: 0, Checks: []types.CheckResult{{Name: "ok", Success: true}}},
+		{Name: "vu1-i1-a", Verb: "POST", URL: "/d", StatusCode: 500, ResponseTime: 1100 * time.Millisecond, Success: false, Error: "HTTP 500 Internal Server Error", Timestamp: base.Add(310 * time.Millisecond), VirtualUserID: 1, IterationID: 1, Checks: []types.CheckResult{{Name: "created", Success: false, FailureMessage: "not ok"}}},
+	}
+	file := writeJSONL(t, dir, "results.jsonl", results)
+
+	fr := NewFileReporter(file)
+	rep, err := fr.GenerateReport(base)
+	if err != nil {
+		t.Fatalf("GenerateReport: %v", err)
+	}
+
+	if rep.TotalRequests != 5 || rep.SuccessfulRequests != 3 || rep.FailedRequests != 2 {
+		t.Fatalf("totals mismatch: %+v", *rep)
+	}
+	if rep.MinResponseTime != 50*time.Millisecond || rep.MaxResponseTime != 1100*time.Millisecond {
+		t.Fatalf("min/max mismatch: min=%v max=%v", rep.MinResponseTime, rep.MaxResponseTime)
+	}
+	if rep.ResponseTimeDistribution["<100ms"] != 1 || rep.ResponseTimeDistribution["100-500ms"] != 2 || rep.ResponseTimeDistribution["500ms-1s"] != 1 || rep.ResponseTimeDistribution[">1s"] != 1 {
+		t.Fatalf("distribution mismatch: %#v", rep.ResponseTimeDistribution)
+	}
+	if rep.ErrorBreakdown["HTTP 500 Internal Server Error"] != 2 {
+		t.Fatalf("error breakdown mismatch: %#v", rep.ErrorBreakdown)
+	}
+	// Check summaries aggregated with de-dup of failure messages
+	created := rep.CheckSummaries["created"]
+	if created.TotalRuns != 2 || created.FailedRuns != 2 || len(created.FailureMessages) != 1 || created.FailureMessages[0] != "not ok" {
+		t.Fatalf("check summary mismatch: %#v", created)
+	}
+	if len(rep.RequestDetails) != len(results) || rep.RequestDetails[0].Name != "vu0-i0-a" || rep.RequestDetails[len(results)-1].Name != "vu1-i1-a" {
+		t.Fatalf("request details ordering mismatch")
+	}
+	// Average equals sum/5 (50+600+120+300+1100 = 2170ms)
+	if rep.AverageResponseTime != (2170*time.Millisecond)/5 {
+		t.Fatalf("average mismatch: %v", rep.AverageResponseTime)
+	}
+}
+
+func TestFileReporter_GenerateHierarchicalReport(t *testing.T) {
+	dir := t.TempDir()
+	base := time.Now()
+	results := []types.RequestResult{
+		{Name: "vu0-i0-a", Verb: "GET", URL: "/a", StatusCode: 200, ResponseTime: 50 * time.Millisecond, Success: true, Timestamp: base.Add(10 * time.Millisecond), VirtualUserID: 0, IterationID: 0},
+		{Name: "vu0-i0-b", Verb: "POST", URL: "/b", StatusCode: 500, ResponseTime: 600 * time.Millisecond, Success: false, Error: "HTTP 500 Internal Server Error", Timestamp: base.Add(20 * time.Millisecond), VirtualUserID: 0, IterationID: 0},
+		{Name: "vu0-i1-a", Verb: "GET", URL: "/a1", StatusCode: 200, ResponseTime: 120 * time.Millisecond, Success: true, Timestamp: base.Add(110 * time.Millisecond), VirtualUserID: 0, IterationID: 1},
+		{Name: "vu1-i0-a", Verb: "GET", URL: "/c", StatusCode: 200, ResponseTime: 300 * time.Millisecond, Success: true, Timestamp: base.Add(210 * time.Millisecond), VirtualUserID: 1, IterationID: 0},
+		{Name: "vu1-i1-a", Verb: "POST", URL: "/d", StatusCode: 500, ResponseTime: 1100 * time.Millisecond, Success: false, Error: "HTTP 500 Internal Server Error", Timestamp: base.Add(310 * time.Millisecond), VirtualUserID: 1, IterationID: 1},
+	}
+	file := writeJSONL(t, dir, "results.jsonl", results)
+
+	fr := NewFileReporter(file)
+	hr, err := fr.GenerateHierarchicalReport(base)
+	if err != nil {
+		t.Fatalf("GenerateHierarchicalReport: %v", err)
+	}
+
+	if hr.TotalVirtualUsers != 2 {
+		t.Fatalf("TotalVirtualUsers mismatch: %d", hr.TotalVirtualUsers)
+	}
+	if len(hr.VirtualUserReports) != 2 {
+		t.Fatalf("unexpected VU reports count: %d", len(hr.VirtualUserReports))
+	}
+
+	// Find reports by GoroutineID
+	var vu0, vu1 *types.GoroutineReport
+	for i := range hr.VirtualUserReports {
+		if hr.VirtualUserReports[i].GoroutineID == 0 {
+			vu0 = &hr.VirtualUserReports[i]
+		}
+		if hr.VirtualUserReports[i].GoroutineID == 1 {
+			vu1 = &hr.VirtualUserReports[i]
+		}
+	}
+	if vu0 == nil || vu1 == nil {
+		t.Fatalf("missing vu0 or vu1 report")
+	}
+
+	if vu0.TotalIterations != 2 || vu1.TotalIterations != 2 {
+		t.Fatalf("iterations mismatch: vu0=%d vu1=%d", vu0.TotalIterations, vu1.TotalIterations)
+	}
+	// vu0 has one failed iteration (iteration 0) and one successful (iteration 1)
+	if vu0.SuccessfulIterations != 1 || vu0.FailedIterations != 1 {
+		t.Fatalf("vu0 iteration success/fail mismatch: %+v", *vu0)
+	}
+	// vu1 has one successful (iter 0) and one failed (iter 1)
+	if vu1.SuccessfulIterations != 1 || vu1.FailedIterations != 1 {
+		t.Fatalf("vu1 iteration success/fail mismatch: %+v", *vu1)
+	}
+	// Check per-iteration request counts and average for vu0 iter0
+	var vu0i0 *types.IterationReport
+	for i := range vu0.Iterations {
+		if vu0.Iterations[i].IterationID == 0 {
+			vu0i0 = &vu0.Iterations[i]
+		}
+	}
+	if vu0i0 == nil {
+		t.Fatalf("missing vu0 iter0")
+	}
+	if vu0i0.TotalRequests != 2 || vu0i0.AverageResponseTime != (50*time.Millisecond+600*time.Millisecond)/2 {
+		t.Fatalf("vu0 iter0 totals/avg mismatch: %+v", *vu0i0)
+	}
+	if len(vu0i0.RequestResults) != 2 || vu0i0.RequestResults[0].Name != "vu0-i0-a" {
+		t.Fatalf("vu0 iter0 results mismatch: %+v", vu0i0.RequestResults)
+	}
+}
+
+func TestFileReporter_ErrorPaths(t *testing.T) {
+	fr := NewFileReporter(filepath.Join(t.TempDir(), "missing.jsonl"))
+	if _, err := fr.GenerateReport(time.Now()); err == nil {
+		t.Fatalf("expected error on missing file for GenerateReport")
+	}
+	if _, err := fr.GenerateHierarchicalReport(time.Now()); err == nil {
+		t.Fatalf("expected error on missing file for GenerateHierarchicalReport")
+	}
+
+	// Invalid JSON line
+	dir := t.TempDir()
+	p := filepath.Join(dir, "bad.jsonl")
+	if err := os.WriteFile(p, []byte("not json\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	fr2 := NewFileReporter(p)
+	if _, err := fr2.GenerateReport(time.Now()); err == nil {
+		t.Fatalf("expected unmarshal error in GenerateReport")
+	}
+	if _, _, err := fr2.collectAllDataInSinglePass(); err == nil { // indirectly used by hierarchical
+		t.Fatalf("expected unmarshal error in collectAllDataInSinglePass")
+	}
+}

--- a/reporting/formatters/console/formatter_console_test.go
+++ b/reporting/formatters/console/formatter_console_test.go
@@ -1,0 +1,20 @@
+package console
+
+import (
+	"github.com/deicon/httprunner/reporting/types"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestConsoleFormatterBasic(t *testing.T) {
+	f := &ConsoleFormatter{}
+	rep := &types.Report{TotalRequests: 1, SuccessfulRequests: 1, StartTime: time.Now(), EndTime: time.Now().Add(time.Second)}
+	out, err := f.Format(rep)
+	if err != nil {
+		t.Fatalf("format: %v", err)
+	}
+	if !strings.Contains(out, "HTTP Request Report") {
+		t.Fatalf("missing title: %s", out)
+	}
+}

--- a/reporting/formatters/csv/formatter_csv_test.go
+++ b/reporting/formatters/csv/formatter_csv_test.go
@@ -1,0 +1,20 @@
+package csv
+
+import (
+	"github.com/deicon/httprunner/reporting/types"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCSVFormatterBasic(t *testing.T) {
+	f := &CSVFormatter{}
+	rep := &types.Report{RequestDetails: []types.RequestResult{{Name: "A", Verb: "GET", URL: "/", Success: true, StatusCode: 200, ResponseTime: 10 * time.Millisecond, Timestamp: time.Now()}}, StartTime: time.Now(), EndTime: time.Now().Add(time.Second)}
+	out, err := f.Format(rep)
+	if err != nil {
+		t.Fatalf("format: %v", err)
+	}
+	if !strings.HasPrefix(out, "Index,Name,Method,URL,Success,StatusCode,ResponseTime,Error,CheckFailures,Timestamp\n") {
+		t.Fatalf("header missing: %s", out)
+	}
+}

--- a/reporting/formatters/html/formatter_html_test.go
+++ b/reporting/formatters/html/formatter_html_test.go
@@ -1,0 +1,20 @@
+package html
+
+import (
+	"github.com/deicon/httprunner/reporting/types"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHTMLFormatterBasic(t *testing.T) {
+	f := &HTMLFormatter{}
+	rep := &types.Report{TotalRequests: 1, SuccessfulRequests: 1, StartTime: time.Now(), EndTime: time.Now().Add(time.Second)}
+	out, err := f.Format(rep)
+	if err != nil {
+		t.Fatalf("format: %v", err)
+	}
+	if !strings.Contains(out, "<title>HTTP Request Report</title>") {
+		t.Fatalf("missing title: %s", out)
+	}
+}

--- a/reporting/formatters/json/formatter_json_test.go
+++ b/reporting/formatters/json/formatter_json_test.go
@@ -1,0 +1,21 @@
+package json
+
+import (
+	"encoding/json"
+	"github.com/deicon/httprunner/reporting/types"
+	"testing"
+	"time"
+)
+
+func TestJSONFormatterBasic(t *testing.T) {
+	f := &JSONFormatter{}
+	rep := &types.Report{TotalRequests: 2, SuccessfulRequests: 2, StartTime: time.Now(), EndTime: time.Now().Add(time.Second)}
+	out, err := f.Format(rep)
+	if err != nil {
+		t.Fatalf("format: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+}

--- a/reporting/formatters_hierarchical_test.go
+++ b/reporting/formatters_hierarchical_test.go
@@ -1,0 +1,148 @@
+package reporting
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/deicon/httprunner/reporting/formatters/hierarchical"
+	"github.com/deicon/httprunner/reporting/types"
+)
+
+func sampleHierarchical() *types.HierarchicalReport {
+	now := time.Now()
+	iter0 := types.IterationReport{
+		IterationID:         0,
+		TotalRequests:       2,
+		SuccessfulRequests:  1,
+		FailedRequests:      1,
+		AverageResponseTime: 150 * time.Millisecond,
+		TotalDuration:       300 * time.Millisecond,
+		StartTime:           now,
+		EndTime:             now.Add(300 * time.Millisecond),
+		RequestResults: []types.RequestResult{
+			{Name: "A", Verb: "GET", URL: "/a", StatusCode: 200, Success: true, ResponseTime: 100 * time.Millisecond, Timestamp: now},
+			{Name: "B", Verb: "POST", URL: "/b", StatusCode: 500, Success: false, Error: "HTTP 500 Internal Server Error", ResponseTime: 200 * time.Millisecond, Timestamp: now.Add(100 * time.Millisecond), Checks: []types.CheckResult{{Name: "created", Success: false, FailureMessage: "bad"}}},
+		},
+	}
+	iter1 := types.IterationReport{
+		IterationID:         1,
+		TotalRequests:       1,
+		SuccessfulRequests:  1,
+		FailedRequests:      0,
+		AverageResponseTime: 50 * time.Millisecond,
+		TotalDuration:       50 * time.Millisecond,
+		StartTime:           now.Add(time.Second),
+		EndTime:             now.Add(time.Second + 50*time.Millisecond),
+		RequestResults: []types.RequestResult{
+			{Name: "C", Verb: "GET", URL: "/c", StatusCode: 200, Success: true, ResponseTime: 50 * time.Millisecond, Timestamp: now.Add(time.Second)},
+		},
+	}
+
+	vu0 := types.GoroutineReport{
+		GoroutineID:          0,
+		Iterations:           []types.IterationReport{iter0, iter1},
+		TotalIterations:      2,
+		SuccessfulIterations: 1,
+		FailedIterations:     1,
+		TotalRequests:        3,
+		SuccessfulRequests:   2,
+		FailedRequests:       1,
+		AverageResponseTime:  100 * time.Millisecond,
+		TotalDuration:        time.Second,
+		StartTime:            now,
+		EndTime:              now.Add(time.Second),
+	}
+
+	summary := types.Report{
+		TotalRequests:       3,
+		SuccessfulRequests:  2,
+		FailedRequests:      1,
+		AverageResponseTime: 100 * time.Millisecond,
+		StartTime:           now,
+		EndTime:             now.Add(2 * time.Second),
+		CheckSummaries: map[string]types.CheckSummary{
+			"created": {Name: "created", TotalRuns: 1, FailedRuns: 1, FailureMessages: []string{"bad"}},
+		},
+		TotalChecks:      1,
+		SuccessfulChecks: 0,
+		FailedChecks:     1,
+	}
+
+	return &types.HierarchicalReport{
+		Summary:                summary,
+		VirtualUserReports:     []types.GoroutineReport{vu0},
+		TotalVirtualUsers:      1,
+		SuccessfulVirtualUsers: 1,
+		FailedVirtualUsers:     0,
+	}
+}
+
+func TestHierarchicalConsoleSnapshots(t *testing.T) {
+	hr := sampleHierarchical()
+	f := &hierarchical.HierarchicalFormatter{DetailLevel: types.DetailIteration, Format: types.FormatConsole}
+	out, err := f.FormatHierarchical(hr)
+	if err != nil {
+		t.Fatalf("format console: %v", err)
+	}
+	for _, s := range []string{
+		"HTTP Request Report - Summary",
+		"Goroutine Breakdown",
+		"Iteration Breakdown",
+		"Goroutine 0:",
+		"Iteration 0:",
+	} {
+		if !strings.Contains(out, s) {
+			t.Fatalf("console output missing %q\n---\n%s", s, out)
+		}
+	}
+}
+
+func TestHierarchicalJSONSnapshot(t *testing.T) {
+	hr := sampleHierarchical()
+	f := &hierarchical.HierarchicalFormatter{DetailLevel: types.DetailIteration, Format: types.FormatJSON}
+	out, err := f.FormatHierarchical(hr)
+	if err != nil {
+		t.Fatalf("format json: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("invalid json: %v\n%s", err, out)
+	}
+	// keys exist
+	if _, ok := parsed["summary"]; !ok {
+		t.Fatalf("missing summary in json")
+	}
+	gs, ok := parsed["goroutines"].([]any)
+	if !ok || len(gs) != 1 {
+		t.Fatalf("goroutines missing or wrong length: %T %v", parsed["goroutines"], parsed["goroutines"])
+	}
+	g0 := gs[0].(map[string]any)
+	if g0["totalIterations"].(float64) != 2 {
+		t.Fatalf("expected totalIterations 2, got %v", g0["totalIterations"])
+	}
+	its, ok := g0["iterations"].([]any)
+	if !ok || len(its) != 2 {
+		t.Fatalf("iterations missing or wrong length")
+	}
+}
+
+func TestHierarchicalHTMLSnapshot(t *testing.T) {
+	hr := sampleHierarchical()
+	f := &hierarchical.HierarchicalFormatter{DetailLevel: types.DetailIteration, Format: types.FormatHTML}
+	out, err := f.FormatHierarchical(hr)
+	if err != nil {
+		t.Fatalf("format html: %v", err)
+	}
+	for _, s := range []string{
+		"<!DOCTYPE html>",
+		"HTTP Request Report - Hierarchical",
+		"Overall Summary",
+		"Total Requests",
+	} {
+		if !strings.Contains(out, s) {
+			t.Fatalf("html output missing %q\n---\n%s", s, out)
+		}
+	}
+}

--- a/reporting/formatters_snapshot_test.go
+++ b/reporting/formatters_snapshot_test.go
@@ -1,0 +1,195 @@
+package reporting
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/deicon/httprunner/metrics"
+	"github.com/deicon/httprunner/reporting/formatters/console"
+	"github.com/deicon/httprunner/reporting/formatters/csv"
+	"github.com/deicon/httprunner/reporting/formatters/html"
+	jsonfmt "github.com/deicon/httprunner/reporting/formatters/json"
+	"github.com/deicon/httprunner/reporting/types"
+)
+
+func sampleReport() *types.Report {
+	now := time.Now()
+	// Request details: one success, one failure with checks
+	reqs := []types.RequestResult{
+		{
+			Name:         "GET /api/items",
+			Verb:         "GET",
+			URL:          "https://example.com/api/items",
+			StatusCode:   200,
+			ResponseTime: 120 * time.Millisecond,
+			Success:      true,
+			Timestamp:    now,
+			Checks:       []types.CheckResult{{Name: "status ok", Success: true}},
+		},
+		{
+			Name:         "POST /api/items",
+			Verb:         "POST",
+			URL:          "https://example.com/api/items",
+			StatusCode:   500,
+			ResponseTime: 800 * time.Millisecond,
+			Success:      false,
+			Error:        "HTTP 500 Internal Server Error",
+			Timestamp:    now.Add(time.Second),
+			Checks: []types.CheckResult{
+				{Name: "created", Success: false, FailureMessage: "not created"},
+			},
+		},
+	}
+
+	// Check summaries
+	checks := map[string]types.CheckSummary{
+		"status ok": {Name: "status ok", TotalRuns: 1, SuccessfulRuns: 1, FailedRuns: 0},
+		"created":   {Name: "created", TotalRuns: 1, SuccessfulRuns: 0, FailedRuns: 1, FailureMessages: []string{"not created"}},
+	}
+
+	// Metrics summaries across types
+	metricsSummaries := map[string]metrics.MetricSummary{
+		"http_reqs":         {Name: "http_reqs", Type: metrics.Counter, Count: 2, Sum: 2, Rate: 2, RateUnit: "req/s"},
+		"http_req_duration": {Name: "http_req_duration", Type: metrics.Trend, Count: 2, Average: 460, Min: 120, Max: 800, P50: 460, P90: 800, P95: 800, P99: 800},
+		"http_req_failed":   {Name: "http_req_failed", Type: metrics.Rate, Count: 2, Average: 0.5},
+		"vus":               {Name: "vus", Type: metrics.Gauge, Count: 1, Average: 1, LatestValue: 1},
+	}
+
+	return &types.Report{
+		TotalRequests:            2,
+		SuccessfulRequests:       1,
+		FailedRequests:           1,
+		AverageResponseTime:      460 * time.Millisecond,
+		MinResponseTime:          120 * time.Millisecond,
+		MaxResponseTime:          800 * time.Millisecond,
+		ResponseTimeDistribution: map[string]int{"<100ms": 0, "100-500ms": 1, "500ms-1s": 1, ">1s": 0},
+		ErrorBreakdown:           map[string]int{"HTTP 500 Internal Server Error": 1},
+		RequestDetails:           reqs,
+		StartTime:                now,
+		EndTime:                  now.Add(2 * time.Second),
+		CheckSummaries:           checks,
+		TotalChecks:              2,
+		SuccessfulChecks:         1,
+		FailedChecks:             1,
+		MetricsSummaries:         metricsSummaries,
+		TotalVirtualUsers:        1,
+		RuntimeSeconds:           2,
+		PerVUMetrics:             map[string]float64{"http_reqs_per_vu": 2},
+		PerIterationMetrics:      map[string]float64{"data_sent_per_iter": 100},
+	}
+}
+
+func TestConsoleFormatterSnapshot(t *testing.T) {
+	rep := sampleReport()
+	f := &console.ConsoleFormatter{}
+	out, err := f.Format(rep)
+	if err != nil {
+		t.Fatalf("console format error: %v", err)
+	}
+	// Spot-check important sections and values
+	checks := []string{
+		"HTTP Request Report",
+		"Total Requests: 2 (1.0 req/s)",
+		"Successful Requests: 1",
+		"Failed Requests: 1",
+		"Response Time Distribution:",
+		"- 100-500ms: 1",
+		"- 500ms-1s: 1",
+		"Error Breakdown:",
+		"HTTP 500 Internal Server Error: 1",
+		"Check Results:",
+		"status ok: 1 runs (1 successful, 0 failed)",
+		"created: 1 runs (0 successful, 1 failed)",
+		"All Collected Metrics:",
+		"Counters:",
+		"Trends:",
+		"Rates:",
+		"Gauges:",
+	}
+	for _, s := range checks {
+		if !strings.Contains(out, s) {
+			t.Fatalf("console output missing %q\n---\n%s", s, out)
+		}
+	}
+}
+
+func TestJSONFormatterSnapshot(t *testing.T) {
+	rep := sampleReport()
+	f := &jsonfmt.JSONFormatter{}
+	out, err := f.Format(rep)
+	if err != nil {
+		t.Fatalf("json format error: %v", err)
+	}
+	// Valid JSON
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("invalid JSON output: %v\n%s", err, out)
+	}
+	// Spot-check keys in JSON string
+	for _, s := range []string{"\"summary\"", "\"totalRequests\": 2", "\"requestDetails\""} {
+		if !strings.Contains(out, s) {
+			t.Fatalf("json output missing %q\n---\n%s", s, out)
+		}
+	}
+}
+
+func TestCSVFormatterSnapshot(t *testing.T) {
+	rep := sampleReport()
+	f := &csv.CSVFormatter{}
+	out, err := f.Format(rep)
+	if err != nil {
+		t.Fatalf("csv format error: %v", err)
+	}
+	// Header and at least two records with expected fields
+	if !strings.HasPrefix(out, "Index,Name,Method,URL,Success,StatusCode,ResponseTime,Error,CheckFailures,Timestamp\n") {
+		t.Fatalf("csv header mismatch:\n%s", out)
+	}
+	if !strings.Contains(out, "1,GET /api/items,GET,https://example.com/api/items,true,200,120ms,,") {
+		t.Fatalf("csv missing first record fields:\n%s", out)
+	}
+	if !strings.Contains(out, ",POST /api/items,POST,https://example.com/api/items,false,500,800ms,HTTP 500 Internal Server Error,not created,") {
+		t.Fatalf("csv missing second record fields:\n%s", out)
+	}
+}
+
+func TestHTMLFormatterSnapshot(t *testing.T) {
+	rep := sampleReport()
+	f := &html.HTMLFormatter{}
+	out, err := f.Format(rep)
+	if err != nil {
+		t.Fatalf("html format error: %v", err)
+	}
+	// Verify title and some key metrics render
+	checks := []string{
+		"<title>HTTP Request Report</title>",
+		"<strong>Total Requests:</strong> 2",
+		"<strong>Successful:</strong>",
+		"<strong>Failed:</strong>",
+		"Response Time Distribution",
+		"Error Breakdown",
+		"Check Results",
+		"📊 All Collected Metrics",
+	}
+	for _, s := range checks {
+		if !strings.Contains(out, s) {
+			t.Fatalf("html output missing %q\n---\n%s", s, out)
+		}
+	}
+}
+
+func TestGetFormatterDispatch(t *testing.T) {
+	if _, ok := GetFormatter(types.FormatHTML).(*html.HTMLFormatter); !ok {
+		t.Fatalf("GetFormatter HTML wrong type")
+	}
+	if _, ok := GetFormatter(types.FormatCSV).(*csv.CSVFormatter); !ok {
+		t.Fatalf("GetFormatter CSV wrong type")
+	}
+	if _, ok := GetFormatter(types.FormatJSON).(*jsonfmt.JSONFormatter); !ok {
+		t.Fatalf("GetFormatter JSON wrong type")
+	}
+	if _, ok := GetFormatter("console").(*console.ConsoleFormatter); !ok {
+		t.Fatalf("GetFormatter default wrong type")
+	}
+}

--- a/reporting/streaming/streaming_test.go
+++ b/reporting/streaming/streaming_test.go
@@ -1,0 +1,78 @@
+package streaming
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/deicon/httprunner/reporting/types"
+)
+
+func readLines(t *testing.T, path string) []string {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			t.Fatalf("close file: %v", err)
+		}
+	}()
+	var lines []string
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		lines = append(lines, s.Text())
+	}
+	if err := s.Err(); err != nil {
+		t.Fatal(err)
+	}
+	return lines
+}
+
+func TestStreamingCollectorWriteAndClose(t *testing.T) {
+	dir := t.TempDir()
+	sc, err := NewStreamingCollector(filepath.Join(dir, "out"))
+	if err != nil {
+		t.Fatalf("NewStreamingCollector: %v", err)
+	}
+	if sc.GetStartTime().IsZero() {
+		t.Fatalf("start time not set")
+	}
+
+	// Write a few results
+	for i := 0; i < 3; i++ {
+		r := types.RequestResult{Name: "req", Verb: "GET", URL: "/x", StatusCode: 200, Success: true, ResponseTime: time.Millisecond, Timestamp: time.Now()}
+		if err := sc.AddResult(r); err != nil {
+			t.Fatalf("AddResult: %v", err)
+		}
+	}
+	if sc.GetResultCount() != 3 {
+		t.Fatalf("expected result count 3, got %d", sc.GetResultCount())
+	}
+
+	path := sc.GetResultsFilePath()
+	if path == "" {
+		t.Fatalf("results file path empty")
+	}
+
+	if err := sc.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Verify file content
+	lines := readLines(t, path)
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d", len(lines))
+	}
+	var rr types.RequestResult
+	if err := json.Unmarshal([]byte(lines[0]), &rr); err != nil {
+		t.Fatalf("line is not JSON: %v", err)
+	}
+	if rr.Name != "req" || rr.StatusCode != 200 {
+		t.Fatalf("unexpected first record: %+v", rr)
+	}
+}

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -1,0 +1,284 @@
+package runner
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	chttp "github.com/deicon/httprunner/http"
+	"github.com/deicon/httprunner/metrics"
+	tpl "github.com/deicon/httprunner/template"
+)
+
+func scriptOnlyRequest(name string, checks int, fail bool) chttp.Request {
+	// Build a script that records a number of checks; last one may fail
+	script := ""
+	for i := 0; i < checks; i++ {
+		if fail && i == checks-1 {
+			script += "client.check(\"c\", function(){ return false; }, \"fail\");\n"
+		} else {
+			script += "client.check(\"c\", function(){ return true; }, \"ok\");\n"
+		}
+	}
+	return chttp.Request{Name: name, Script: script}
+}
+
+func TestRunnerRunWithScriptOnlyRequests(t *testing.T) {
+	// One VU, two iterations, one script-only normal request per iteration
+	reqs := []chttp.Request{
+		{Name: "BeforeUser", Lifecycle: chttp.LifecycleBeforeUser, Script: "client.global.set(\"x\", 1)"},
+		{Name: "BeforeIteration", Lifecycle: chttp.LifecycleBeforeIteration, Script: "client.global.set(\"y\", 2)"},
+		scriptOnlyRequest("DoWork", 1, false),
+		{Name: "TeardownIteration", Lifecycle: chttp.LifecycleTeardownIteration, Script: "/*noop*/"},
+		{Name: "TeardownUser", Lifecycle: chttp.LifecycleTeardownUser, Script: "/*noop*/"},
+	}
+
+	r, err := NewRunner(1, 2, 0, reqs, t.TempDir())
+	if err != nil {
+		t.Fatalf("NewRunner: %v", err)
+	}
+
+	report, err := r.Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if report.TotalRequests != 2 || report.FailedRequests != 0 {
+		t.Fatalf("unexpected totals: %+v", report)
+	}
+	// Response time distribution should categorize zeros as <100ms
+	if report.ResponseTimeDistribution["<100ms"] != 2 {
+		t.Fatalf("unexpected distribution: %#v", report.ResponseTimeDistribution)
+	}
+}
+
+func TestRunnerRunHierarchicalWithConcurrency(t *testing.T) {
+	// Two VUs, two iterations, one script-only request per iteration that has one failing check
+	reqs := []chttp.Request{scriptOnlyRequest("DoWork", 2, true)}
+
+	r, err := NewRunner(2, 2, 0, reqs, t.TempDir())
+	if err != nil {
+		t.Fatalf("NewRunner: %v", err)
+	}
+
+	hr, err := r.RunHierarchical()
+	if err != nil {
+		t.Fatalf("RunHierarchical: %v", err)
+	}
+
+	if hr.TotalVirtualUsers != 2 || len(hr.VirtualUserReports) != 2 {
+		t.Fatalf("unexpected VU count: %d (%d reports)", hr.TotalVirtualUsers, len(hr.VirtualUserReports))
+	}
+	// Each VU performs 2 iterations with 1 request each -> 2 requests
+	for _, gr := range hr.VirtualUserReports {
+		if gr.TotalIterations != 2 || gr.TotalRequests != 2 {
+			t.Fatalf("unexpected per-VU totals: %+v", gr)
+		}
+	}
+}
+
+func TestRunnerExecute_TemplatingAndScripts(t *testing.T) {
+	// Start a local server to capture headers/body
+	var gotAuth, gotTrace, gotBody, gotPath string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotTrace = r.Header.Get("X-Trace")
+		b, _ := io.ReadAll(r.Body)
+		_ = r.Body.Close()
+		gotBody = string(b)
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer ts.Close()
+
+	r := &Runner{MetricsCollector: metrics.NewMetricsCollector()}
+	te := tpl.NewTemplateEngine()
+	te.SetMetricsCollector(r.MetricsCollector)
+	te.GetGlobalStore().Set("BASE", ts.URL)
+	te.GetGlobalStore().Set("TOKEN", "abc")
+
+	req := chttp.Request{
+		Name: "Create",
+		Verb: "POST",
+		URL:  "{{.BASE}}/api/{{.id}}",
+		Headers: map[string]string{
+			"Authorization": "Bearer {{.TOKEN}}",
+			"X-Trace":       "{{.trace}}",
+			"Content-Type":  "application/json",
+		},
+		Body:      `{"n":"{{.name}}"}`,
+		PreScript: `client.global.set("id","v1"); client.global.set("trace","tr-123"); client.global.set("name","bob");`,
+		Script:    `client.check("ok", function(){ return response.body.ok === true; }, "not ok");`,
+	}
+
+	res := r.execute(req, te, 0, 0)
+	if !res.Success || res.StatusCode != http.StatusCreated {
+		t.Fatalf("expected success 201, got %+v", res)
+	}
+	if !strings.HasSuffix(res.URL, "/api/v1") {
+		t.Fatalf("templated URL not applied: %s", res.URL)
+	}
+	if gotAuth != "Bearer abc" || gotTrace != "tr-123" {
+		t.Fatalf("templated headers not applied: auth=%q trace=%q", gotAuth, gotTrace)
+	}
+	if !strings.Contains(gotBody, "bob") {
+		t.Fatalf("templated body not applied: %s", gotBody)
+	}
+	if gotPath != "/api/v1" {
+		t.Fatalf("unexpected path: %s", gotPath)
+	}
+	// Metrics collector should have recorded HTTP timings
+	if r.MetricsCollector.GetMetric("http_req_duration").GetCount() == 0 {
+		t.Fatalf("http_req_duration metric not recorded")
+	}
+}
+
+func TestRunnerExecute_FailureAndError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	r := &Runner{MetricsCollector: metrics.NewMetricsCollector()}
+	te := tpl.NewTemplateEngine()
+	te.SetMetricsCollector(r.MetricsCollector)
+	te.GetGlobalStore().Set("BASE", ts.URL)
+
+	req := chttp.Request{Name: "X", Verb: "GET", URL: "{{.BASE}}/fail"}
+	res := r.execute(req, te, 0, 0)
+	if res.Success || res.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected failure with 500, got %+v", res)
+	}
+	if !strings.Contains(res.Error, "HTTP 500") {
+		t.Fatalf("expected HTTP 500 error message, got %q", res.Error)
+	}
+}
+
+func TestRunnerExecuteForFunction_HTTPAndScriptOnly(t *testing.T) {
+	// HTTP path
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"k": "v"})
+	}))
+	defer ts.Close()
+
+	r := &Runner{MetricsCollector: metrics.NewMetricsCollector()}
+	te := tpl.NewTemplateEngine()
+	te.SetMetricsCollector(r.MetricsCollector)
+	te.GetGlobalStore().Set("BASE", ts.URL)
+
+	httpReq := chttp.Request{Name: "HTTP", Verb: "GET", URL: "{{.BASE}}/ok"}
+	resp, err := r.executeForFunction(httpReq, te, 1, 2)
+	if err != nil || resp.StatusCode == 0 {
+		t.Fatalf("executeForFunction http failed: resp=%+v err=%v", resp, err)
+	}
+	if resp.Body.(map[string]any)["k"].(string) != "v" {
+		t.Fatalf("unexpected response body: %+v", resp.Body)
+	}
+
+	// Script-only path
+	so := chttp.Request{Name: "SO", Script: "/* noop */"}
+	resp2, err := r.executeForFunction(so, te, -1, -1)
+	if err != nil || resp2.StatusCode != 200 {
+		t.Fatalf("script-only executeForFunction failed: %+v err=%v", resp2, err)
+	}
+
+	// Give some time for metrics flush to avoid race with rate calculations
+	time.Sleep(5 * time.Millisecond)
+}
+
+func TestRunnerExecute_PreScriptError(t *testing.T) {
+	r := &Runner{MetricsCollector: metrics.NewMetricsCollector()}
+	te := tpl.NewTemplateEngine()
+	te.SetMetricsCollector(r.MetricsCollector)
+	// Invalid JS
+	req := chttp.Request{Name: "BadPre", Verb: "GET", URL: "http://example.invalid", PreScript: "function(){"}
+	res := r.execute(req, te, 0, 0)
+	if res.Success || !strings.Contains(res.Error, "error executing pre-request script") {
+		t.Fatalf("expected pre-script error, got: %+v", res)
+	}
+}
+
+func TestRunnerExecute_PostScriptError(t *testing.T) {
+	// Server returns valid JSON but script fails
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer ts.Close()
+	r := &Runner{MetricsCollector: metrics.NewMetricsCollector()}
+	te := tpl.NewTemplateEngine()
+	te.SetMetricsCollector(r.MetricsCollector)
+	te.GetGlobalStore().Set("BASE", ts.URL)
+	req := chttp.Request{Name: "BadPost", Verb: "GET", URL: "{{.BASE}}/x", Script: "function(){"}
+	res := r.execute(req, te, 0, 0)
+	if res.Success || !strings.Contains(res.Error, "error executing script") {
+		t.Fatalf("expected post-script error, got: %+v", res)
+	}
+}
+
+func TestRunnerExecute_HeaderKeyTemplateError(t *testing.T) {
+	r := &Runner{MetricsCollector: metrics.NewMetricsCollector()}
+	te := tpl.NewTemplateEngine()
+	te.SetMetricsCollector(r.MetricsCollector)
+	req := chttp.Request{Name: "BadHeaderKey", Verb: "GET", URL: "http://example.com", Headers: map[string]string{"{{ .bad |": "x"}}
+	res := r.execute(req, te, 0, 0)
+	if res.Success || !strings.Contains(res.Error, "error rendering header key template") {
+		t.Fatalf("expected header key template error, got: %+v", res)
+	}
+}
+
+func TestRunnerExecute_HeaderValueTemplateError(t *testing.T) {
+	r := &Runner{MetricsCollector: metrics.NewMetricsCollector()}
+	te := tpl.NewTemplateEngine()
+	te.SetMetricsCollector(r.MetricsCollector)
+	req := chttp.Request{Name: "BadHeaderVal", Verb: "GET", URL: "http://example.com", Headers: map[string]string{"X": "{{ .bad |"}}
+	res := r.execute(req, te, 0, 0)
+	if res.Success || !strings.Contains(res.Error, "error rendering header value template") {
+		t.Fatalf("expected header value template error, got: %+v", res)
+	}
+}
+
+func TestRunnerExecute_BodyTemplateError(t *testing.T) {
+	r := &Runner{MetricsCollector: metrics.NewMetricsCollector()}
+	te := tpl.NewTemplateEngine()
+	te.SetMetricsCollector(r.MetricsCollector)
+	req := chttp.Request{Name: "BadBody", Verb: "POST", URL: "http://example.com", Body: "{{ .nope |"}
+	res := r.execute(req, te, 0, 0)
+	if res.Success || !strings.Contains(res.Error, "error rendering body template") {
+		t.Fatalf("expected body template error, got: %+v", res)
+	}
+}
+
+func TestRunnerExecute_URLTemplateError(t *testing.T) {
+	r := &Runner{MetricsCollector: metrics.NewMetricsCollector()}
+	te := tpl.NewTemplateEngine()
+	te.SetMetricsCollector(r.MetricsCollector)
+	req := chttp.Request{Name: "BadURL", Verb: "GET", URL: "{{ .oops |"}
+	res := r.execute(req, te, 0, 0)
+	if res.Success || !strings.Contains(res.Error, "error rendering URL template") {
+		t.Fatalf("expected URL template error, got: %+v", res)
+	}
+}
+
+func TestRunnerExecute_RequestNameFallback(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+	r := &Runner{MetricsCollector: metrics.NewMetricsCollector()}
+	te := tpl.NewTemplateEngine()
+	te.SetMetricsCollector(r.MetricsCollector)
+	te.GetGlobalStore().Set("BASE", ts.URL)
+	req := chttp.Request{Name: "", Verb: "GET", URL: "{{.BASE}}/fallback"}
+	res := r.execute(req, te, 0, 0)
+	if !res.Success {
+		t.Fatalf("expected success: %+v", res)
+	}
+	if !strings.HasPrefix(res.Name, "GET ") || !strings.Contains(res.Name, "/fallback") {
+		t.Fatalf("fallback name not applied: %q", res.Name)
+	}
+}

--- a/template/additional_template_test.go
+++ b/template/additional_template_test.go
@@ -1,0 +1,98 @@
+package template
+
+import (
+	"fmt"
+	chttp "github.com/deicon/httprunner/http"
+	"github.com/deicon/httprunner/metrics"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewTemplateEngineWithEnvFile_LoadsEnv(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+	content := "API_URL=\"https://example.com\"\nTOKEN=abc123\n# comment\nINVALID_LINE\n"
+	if err := os.WriteFile(envPath, []byte(content), 0644); err != nil {
+		t.Fatalf("write env: %v", err)
+	}
+
+	eng, err := NewTemplateEngineWithEnvFile(envPath)
+	if err != nil {
+		t.Fatalf("NewTemplateEngineWithEnvFile: %v", err)
+	}
+	if got := eng.GetGlobalStore().Get("API_URL"); got != "https://example.com" {
+		t.Fatalf("API_URL not loaded correctly: %v", got)
+	}
+	if got := eng.GetGlobalStore().Get("TOKEN"); got != "abc123" {
+		t.Fatalf("TOKEN not loaded correctly: %v", got)
+	}
+}
+
+func TestRenderTemplate_Error(t *testing.T) {
+	eng := NewTemplateEngine()
+	if _, err := eng.RenderTemplate("Hello {{ .MISSING | "); err == nil {
+		t.Fatalf("expected template parse error")
+	}
+}
+
+func TestRequestExecutorErrorPropagation(t *testing.T) {
+	eng := NewTemplateEngine()
+	eng.RegisterRequestFunction(chttp.Request{Name: "ErrFunc", Verb: "GET", URL: "http://example.com"})
+	eng.SetRequestExecutor(func(req chttp.Request) (*Response, error) {
+		return nil, fmt.Errorf("boom")
+	})
+
+	script := `
+        var r = client.errfunc();
+        client.global.set("call_success", r.success);
+        client.global.set("call_error", r.error);
+    `
+	if err := eng.ExecuteScript(script, "", 0, 0); err != nil {
+		t.Fatalf("ExecuteScript: %v", err)
+	}
+	if eng.GetGlobalStore().Get("call_success") != false {
+		t.Fatalf("expected success=false")
+	}
+	if eng.GetGlobalStore().Get("call_error") == nil {
+		t.Fatalf("expected error message to be set")
+	}
+}
+
+func TestMetricsAccessInScripts(t *testing.T) {
+	eng := NewTemplateEngine()
+	mc := metrics.NewMetricsCollector()
+	// Record some metrics
+	mc.RecordHTTPRequest(10_000_000, 0, 0, 0, 0, 0, 0, false, 100, 200, map[string]string{"url": "/x"})
+	mc.RecordCheck(true, nil)
+	mc.UpdateVirtualUsers(1, 1)
+	eng.SetMetricsCollector(mc)
+
+	script := `
+        var m = client.metrics.get("http_req_duration");
+        client.global.set("m_name", m.name);
+        client.global.set("m_count", m.count);
+        var cur = client.metrics.getCurrent("vus");
+        client.global.set("vus_current", cur);
+        var all = client.metrics.getAll();
+        var http_reqs = all["http_reqs"];
+        client.global.set("http_reqs_count", http_reqs.count);
+    `
+
+	if err := eng.ExecuteScript(script, "", 0, 0); err != nil {
+		t.Fatalf("ExecuteScript: %v", err)
+	}
+
+	if eng.GetGlobalStore().Get("m_name") != "http_req_duration" {
+		t.Fatalf("expected metric name http_req_duration, got %v", eng.GetGlobalStore().Get("m_name"))
+	}
+	if eng.GetGlobalStore().Get("m_count") == 0 {
+		t.Fatalf("expected non-zero count for http_req_duration")
+	}
+	if eng.GetGlobalStore().Get("vus_current") == nil {
+		t.Fatalf("expected current vus metric value to be set")
+	}
+	if eng.GetGlobalStore().Get("http_reqs_count") == 0 {
+		t.Fatalf("expected non-zero http_reqs count")
+	}
+}


### PR DESCRIPTION
This PR adds broad unit test coverage across key components.\n\nHighlights:\n- Tests for: harparser, httprunner, metrics, reporting (console/csv/html/json), hierarchical formatter, streaming, runner, and template utilities.\n- Ensures golangci-lint compliance by checking Close() errors in tests.\n- No production code changes; tests only.\n\nCI should now include these tests to improve regression safety.