### PR TITLE
feat: version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,7 +247,7 @@ jobs:
     needs: [test, build]
     runs-on: ubuntu-latest
     # Run only when a PR into develop is closed and merged (supports squash/rebase/merge)
-    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'develop'
+    if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,13 +1,4 @@
 
-# Get list of staged Go files
-STAGED_GO_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.go$')
-
-# If no Go files are staged, exit early
-if [ -z "$STAGED_GO_FILES" ]; then
-  echo "No Go files staged, skipping pre-commit hooks"
-  exit 0
-fi
-
 echo "Running pre-commit hooks on Go files..."
 
 # Run make fmt


### PR DESCRIPTION
```
Description:
This PR focuses on improving the CLI experience by adding a version flag to both `harparser` and `httprunner` tools and refactors the semantic release workflow. Additionally, it simplifies the husky hooks.

Motivation:
- Adding a version flag allows users to easily check the version of the CLI tools they are using.
- The previous semantic release workflow was triggered incorrectly. This commit fixes the trigger to ensure it runs only on pushes to the `develop` branch.
- Simplify husky hooks to prevent errors when non Go files are commited.

What was changed:
- **`.github/workflows/ci.yml`**: Modified the `semantic_release` job to trigger on `push` events to the `develop` branch (`github.ref == 'refs/heads/develop'`) instead of PR merges.
- **`.husky/commit-msg`**: Simplified by removing the shebang and direct execution of husky.
- **`.husky/pre-commit`**: Removed Go specific logic to run on all commits.
- **`cmd/harparser/main.go`**: Added a `version` variable (populated at build time) and a `-version` and `-V` flag to print the version and exit.
- **`cmd/httprunner/main.go`**: Added a `version` variable (populated at build time) and a `-version` and `-V` flag to print the version and exit.

Tests:
No new tests were added or existing tests were modified.  **Please ensure that the changes to the CI workflow and husky hooks do not negatively impact the build or release process.**  Manual verification that the version flags work as expected is recommended.
```

