### PR TITLE
feat: brew formulas

### DIFF
--- a/.github/scripts/generate_formula.sh
+++ b/.github/scripts/generate_formula.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Inputs
+REPO="${GITHUB_REPOSITORY:-deicon/httprunner}"
+TAG="${1:?usage: generate_formula.sh <tag> (e.g., v1.2.3)}"
+VERSION_STRIPPED="${TAG#v}"
+BUILD_DIR="build"
+
+base_url="https://github.com/${REPO}/releases/download/${TAG}"
+
+sha256_for() {
+  local file="$1"
+  shasum -a 256 "$file" | awk '{print $1}'
+}
+
+write_formula() {
+  local tool="$1"
+
+  local darwin_arm64_file="${tool}_${TAG}_darwin_arm64.tar.gz"
+  local darwin_amd64_file="${tool}_${TAG}_darwin_amd64.tar.gz"
+  local linux_arm64_file="${tool}_${TAG}_linux_arm64.tar.gz"
+  local linux_amd64_file="${tool}_${TAG}_linux_amd64.tar.gz"
+
+  local darwin_arm64_sha linux_arm64_sha darwin_amd64_sha linux_amd64_sha
+  darwin_arm64_sha=$(sha256_for "${BUILD_DIR}/${darwin_arm64_file}")
+  darwin_amd64_sha=$(sha256_for "${BUILD_DIR}/${darwin_amd64_file}")
+  linux_arm64_sha=$(sha256_for "${BUILD_DIR}/${linux_arm64_file}")
+  linux_amd64_sha=$(sha256_for "${BUILD_DIR}/${linux_amd64_file}")
+
+  local class_name
+  case "$tool" in
+    httprunner) class_name="Httprunner" ;;
+    harparser) class_name="Harparser" ;;
+    *) echo "Unknown tool: $tool" >&2; exit 1 ;;
+  esac
+
+  cat > "Formula/${tool}.rb" <<EOF
+class ${class_name} < Formula
+  desc "$( [ "$tool" = "httprunner" ] && echo "Parallel HTTP scenario runner" || echo "HAR to .http extractor" )"
+  homepage "https://github.com/deicon/httprunner"
+  version "${VERSION_STRIPPED}"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "${base_url}/${darwin_arm64_file}"
+      sha256 "${darwin_arm64_sha}"
+    else
+      url "${base_url}/${darwin_amd64_file}"
+      sha256 "${darwin_amd64_sha}"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "${base_url}/${linux_arm64_file}"
+      sha256 "${linux_arm64_sha}"
+    else
+      url "${base_url}/${linux_amd64_file}"
+      sha256 "${linux_amd64_sha}"
+    end
+  end
+
+  def install
+    bin.install "${tool}"
+  end
+
+  test do
+    system "#{bin}/${tool}", "-version"
+  end
+end
+EOF
+}
+
+write_formula httprunner
+write_formula harparser
+
+echo "Updated Formula/httprunner.rb and Formula/harparser.rb for ${TAG}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,15 +177,38 @@ jobs:
       
     - name: Create release archives
       run: |
+        set -euo pipefail
+        TAG="${{ github.event.release.tag_name }}"
+        echo "Packaging archives for ${TAG}"
         cd build
+        shopt -s nullglob
         for file in httprunner-* harparser-*; do
-          if [[ "$file" == *".exe" ]]; then
-            # Windows executable - create zip
-            zip "${file%.exe}.zip" "$file"
+          base=$(basename "$file")
+          # Parse tool, os, arch
+          tool=${base%%-*}
+          rest=${base#${tool}-}
+          os=${rest%%-*}
+          arch_ext=${rest#${os}-}
+          arch=${arch_ext%%.*}
+          ext=""
+          if [[ "$base" == *.exe ]]; then
+            # Windows
+            ext="zip"
+            out="${tool}_${TAG}_windows_${arch}.${ext}"
+            tmpdir=$(mktemp -d)
+            cp "$base" "$tmpdir/${tool}.exe"
+            (cd "$tmpdir" && zip -q "${OLDPWD}/${out}" "${tool}.exe")
+            rm -rf "$tmpdir"
           else
-            # Unix executable - create tar.gz
-            tar -czf "${file}.tar.gz" "$file"
+            # Unix
+            ext="tar.gz"
+            out="${tool}_${TAG}_${os}_${arch}.${ext}"
+            tmpdir=$(mktemp -d)
+            cp "$base" "$tmpdir/${tool}"
+            (cd "$tmpdir" && tar -czf "${OLDPWD}/${out}" "${tool}")
+            rm -rf "$tmpdir"
           fi
+          echo "Created $out"
         done
         
     - name: Upload release assets
@@ -196,6 +219,18 @@ jobs:
           build/*.tar.gz
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Update Homebrew formulas
+      if: success()
+      run: |
+        chmod +x .github/scripts/generate_formula.sh
+        TAG="${{ github.event.release.tag_name }}"
+        .github/scripts/generate_formula.sh "$TAG"
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add Formula/httprunner.rb Formula/harparser.rb
+        git commit -m "chore(homebrew): update formulas for ${TAG}"
+        git push origin "HEAD:${{ github.event.repository.default_branch }}"
 
   docker:
     name: Docker Build

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,5 +1,2 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh" 2>/dev/null || true
-
 npx --no -- commitlint --edit "$1"
 

--- a/Formula/harparser.rb
+++ b/Formula/harparser.rb
@@ -1,0 +1,35 @@
+class Harparser < Formula
+  desc "HAR to .http extractor"
+  homepage "https://github.com/deicon/httprunner"
+  version "0.0.0" # updated by CI on release
+
+  # URLs and sha256 are set per-platform by CI on release
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/deicon/httprunner/releases/download/v0.0.0/harparser_v0.0.0_darwin_arm64.tar.gz"
+      sha256 "deadbeef"
+    else
+      url "https://github.com/deicon/httprunner/releases/download/v0.0.0/harparser_v0.0.0_darwin_amd64.tar.gz"
+      sha256 "deadbeef"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "https://github.com/deicon/httprunner/releases/download/v0.0.0/harparser_v0.0.0_linux_arm64.tar.gz"
+      sha256 "deadbeef"
+    else
+      url "https://github.com/deicon/httprunner/releases/download/v0.0.0/harparser_v0.0.0_linux_amd64.tar.gz"
+      sha256 "deadbeef"
+    end
+  end
+
+  def install
+    bin.install "harparser"
+  end
+
+  test do
+    system "#{bin}/harparser", "-version"
+  end
+end
+

--- a/Formula/httprunner.rb
+++ b/Formula/httprunner.rb
@@ -1,0 +1,35 @@
+class Httprunner < Formula
+  desc "Parallel HTTP scenario runner"
+  homepage "https://github.com/deicon/httprunner"
+  version "0.0.0" # updated by CI on release
+
+  # URLs and sha256 are set per-platform by CI on release
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/deicon/httprunner/releases/download/v0.0.0/httprunner_v0.0.0_darwin_arm64.tar.gz"
+      sha256 "deadbeef"
+    else
+      url "https://github.com/deicon/httprunner/releases/download/v0.0.0/httprunner_v0.0.0_darwin_amd64.tar.gz"
+      sha256 "deadbeef"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "https://github.com/deicon/httprunner/releases/download/v0.0.0/httprunner_v0.0.0_linux_arm64.tar.gz"
+      sha256 "deadbeef"
+    else
+      url "https://github.com/deicon/httprunner/releases/download/v0.0.0/httprunner_v0.0.0_linux_amd64.tar.gz"
+      sha256 "deadbeef"
+    end
+  end
+
+  def install
+    bin.install "httprunner"
+  end
+
+  test do
+    system "#{bin}/httprunner", "-version"
+  end
+end
+

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test-coverage:
 .PHONY: build
 build:
 	go build $(LDFLAGS) -o $(BUILD_DIR)/httprunner ./cmd/httprunner
-	go build $(LDFLAGS) -o $(BUILD_DIR)/harparserr ./cmd/harparser
+	go build $(LDFLAGS) -o $(BUILD_DIR)/harparser ./cmd/harparser
 
 # Build for all platforms
 .PHONY: build-all
@@ -44,7 +44,7 @@ build-all: clean
 	GOOS=windows GOARCH=386 go build $(LDFLAGS) -o $(BUILD_DIR)/httprunner-windows-386.exe ./cmd/httprunner
 	GOOS=windows GOARCH=amd64 go build $(LDFLAGS) -o $(BUILD_DIR)/httprunner-windows-amd64.exe ./cmd/httprunner
 	GOOS=windows GOARCH=arm64 go build $(LDFLAGS) -o $(BUILD_DIR)/httprunner-windows-arm64.exe ./cmd/httprunner
-	GOOS=windows GOARCH=386 go build $(LDFLAGS) -o $(BUILD_DIR)/harparsers-windows-386.exe ./cmd/harparser
+	GOOS=windows GOARCH=386 go build $(LDFLAGS) -o $(BUILD_DIR)/harparser-windows-386.exe ./cmd/harparser
 	GOOS=windows GOARCH=amd64 go build $(LDFLAGS) -o $(BUILD_DIR)/harparser-windows-amd64.exe ./cmd/harparser
 	GOOS=windows GOARCH=arm64 go build $(LDFLAGS) -o $(BUILD_DIR)/harparser-windows-arm64.exe ./cmd/harparser
 	

--- a/README.md
+++ b/README.md
@@ -2,6 +2,52 @@
 
 A Go-based command-line tool for running multiple, parallel HTTP requests.
 
+## Installation
+
+### Using `go install`
+
+Prerequisites: Go 1.20+ and a working internet connection.
+
+Install the CLI tools directly from the module:
+
+```bash
+go install github.com/deicon/httprunner/cmd/httprunner@latest
+go install github.com/deicon/httprunner/cmd/harparser@latest
+```
+
+Ensure your install bin directory is on PATH:
+
+```bash
+export PATH="$(go env GOPATH)/bin:$PATH"   # if GOBIN not set
+```
+
+Verify installation and version:
+
+```bash
+httprunner -version
+harparser -version
+```
+
+Notes:
+- Replace `@latest` with a specific tag (e.g., `@vX.Y.Z`) to pin a version.
+- To upgrade later, rerun the same `go install ...@latest` commands.
+
+### Homebrew (macOS/Linux)
+
+Once a release is published, prebuilt bottles are provided via Formula files in this repo. Install directly from the raw formula URLs:
+
+```bash
+# httprunner
+brew install --formula https://raw.githubusercontent.com/deicon/httprunner/refs/heads/main/Formula/httprunner.rb
+
+# harparser
+brew install --formula https://raw.githubusercontent.com/deicon/httprunner/refs/heads/main/Formula/harparser.rb
+```
+
+Notes:
+- Homebrew supports macOS and Linux; Windows users can download the ZIP asset from Releases.
+- The CI release job updates these formulas with per-platform URLs and SHA256 checksums automatically on every tagged release.
+
 ## Project Structure
 
 ```

--- a/cmd/harparser/main.go
+++ b/cmd/harparser/main.go
@@ -9,6 +9,9 @@ import (
 	"strings"
 )
 
+// version is populated at build time via ldflags (-X main.version=...)
+var version = "dev"
+
 type multiStringFlag []string
 
 func (m *multiStringFlag) String() string {
@@ -107,6 +110,10 @@ func parseFlags() Config {
 	var config Config
 	var filters multiStringFlag
 
+	// version flags are parsed early via the default CommandLine; support -version and -V
+	showVersion := flag.Bool("version", false, "Print version and exit")
+	flag.BoolVar(showVersion, "V", false, "Print version and exit")
+
 	flag.StringVar(&config.InputFile, "f", "", "Input HAR file path (required)")
 	flag.StringVar(&config.InputFile, "file", "", "Input HAR file path (required)")
 	flag.StringVar(&config.OutputFile, "o", "", "Output .http file path (optional, prints to stdout if not specified)")
@@ -116,6 +123,11 @@ func parseFlags() Config {
 	flag.BoolVar(&config.Help, "help", false, "Show help")
 
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Println(version)
+		os.Exit(0)
+	}
 
 	config.Filters = []string(filters)
 	return config

--- a/cmd/httprunner/main.go
+++ b/cmd/httprunner/main.go
@@ -14,8 +14,13 @@ import (
 	"github.com/deicon/httprunner/runner"
 )
 
+// version is populated at build time via ldflags (-X main.version=...)
+var version = "dev"
+
 func main() {
 	// Command line flags
+	showVersion := flag.Bool("version", false, "Print version and exit")
+	flag.BoolVar(showVersion, "V", false, "Print version and exit")
 	concurrency := flag.Int("u", 1, "Number of parallel virtual parallel users")
 	iterations := flag.Int("i", 1, "Number of iterations")
 	runtime := flag.Int("r", 0, "Runtime duration in seconds (0 means use iterations)")
@@ -27,6 +32,11 @@ func main() {
 	reportDetail := flag.String("detail", "summary", "Report detail level: summary, goroutine, iteration, full")
 
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Println(version)
+		return
+	}
 
 	if *requestFile == "" {
 		fmt.Println("Error: -f flag is required")


### PR DESCRIPTION
```
feat: Homebrew formula generation and CI integration

Description:
This PR introduces a new script to automatically generate Homebrew formulas for `httprunner` and `harparser` on release. It also integrates this script into the CI workflow to keep the formulas up-to-date.

Motivation:
Manually updating the Homebrew formulas for each release is tedious and error-prone. This change automates the process, ensuring that users can easily install the latest versions of `httprunner` and `harparser` via Homebrew.

What was changed:
- Added a new script `.github/scripts/generate_formula.sh` that generates the Homebrew formulas for `httprunner` and `harparser` based on the release tag.
- Modified `.github/workflows/ci.yml` to:
    - Package archives with the tool name, tag, OS, and architecture.
    - Call the `generate_formula.sh` script on release.
    - Commit and push the updated formulas to the repository.
- Added new Formula files `Formula/harparser.rb` and `Formula/httprunner.rb` which are used as templates and updated by the script
- Modified the Makefile to correctly name the `harparser` output file.
- Updated the README to include installation instructions via Homebrew

Tests:
No new tests were added. The existing test in the generated Homebrew formula is used to verify the installation.

**Warning:** The generated Homebrew formulas currently contain placeholder values for the URL and SHA256 checksums. These values are updated by the CI workflow on release. Local testing of the script will not produce valid formulas without setting the correct environment variables and having the built binaries available.
```
