### PR TITLE
feat: New and update metrics on html report

### DIFF
--- a/reporting/formatters/html/formatter_html.go
+++ b/reporting/formatters/html/formatter_html.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	_ "embed"
 	"html/template"
+	"strings"
 	"time"
 
 	"github.com/deicon/httprunner/reporting/types"
@@ -17,8 +18,9 @@ var htmlTemplate string
 
 func (f *HTMLFormatter) Format(report *types.Report) (string, error) {
 	tmpl, err := template.New("report").Funcs(template.FuncMap{
-		"add": func(a, b int) int { return a + b },
-		"mul": func(a, b float64) float64 { return a * b },
+		"add":         func(a, b int) int { return a + b },
+		"mul":         func(a, b float64) float64 { return a * b },
+		"stripSuffix": func(s, suffix string) string { return strings.TrimSuffix(s, suffix) },
 	}).Parse(htmlTemplate)
 	if err != nil {
 		return "", err

--- a/reporting/formatters/html/templates/htmlTemplate.html
+++ b/reporting/formatters/html/templates/htmlTemplate.html
@@ -30,6 +30,12 @@
     <div class="metric"><strong>Min Response Time:</strong> {{.MinResponseTime}}</div>
     <div class="metric"><strong>Max Response Time:</strong> {{.MaxResponseTime}}</div>
     <div class="metric"><strong>Total Duration:</strong> {{.TotalDuration}}</div>
+    {{if gt .TotalVirtualUsers 0}}
+    <div class="metric"><strong>Virtual Users:</strong> {{.TotalVirtualUsers}}</div>
+    {{end}}
+    {{if gt .RuntimeSeconds 0.0}}
+    <div class="metric"><strong>Runtime:</strong> {{printf "%.1fs" .RuntimeSeconds}}</div>
+    {{end}}
 </div>
 
 {{if .ResponseTimeDistribution}}
@@ -92,10 +98,15 @@
 
     <h4>Counters</h4>
     <table style="margin-bottom: 20px;">
-        <tr><th>Metric</th><th>Value</th><th>Count</th></tr>
+        <tr><th>Metric</th><th>Value</th><th>Count</th><th>Rate</th></tr>
         {{range $name, $summary := .MetricsSummaries}}
         {{if eq $summary.Type "counter"}}
-        <tr><td>{{$name}}</td><td>{{printf "%.0f" $summary.Sum}}</td><td>{{$summary.Count}}</td></tr>
+        <tr>
+            <td>{{$name}}</td>
+            <td>{{printf "%.0f" $summary.Sum}}</td>
+            <td>{{$summary.Count}}</td>
+            <td>{{if gt $summary.Rate 0.0}}{{printf "%.1f %s" $summary.Rate $summary.RateUnit}}{{else}}-{{end}}</td>
+        </tr>
         {{end}}
         {{end}}
     </table>
@@ -138,6 +149,38 @@
         {{end}}
     </table>
 </div>
+{{end}}
+
+{{if .PerVUMetrics}}
+<div class="summary">
+    <h3>👤 Per Virtual User Metrics</h3>
+    <table style="margin-bottom: 20px;">
+        <tr><th>Metric</th><th>Per VU</th></tr>
+        {{range $name, $value := .PerVUMetrics}}
+        <tr>
+            <td>{{stripSuffix $name "_per_vu"}}</td>
+            <td>{{printf "%.2f" $value}}</td>
+        </tr>
+        {{end}}
+    </table>
+    <small>Values represent totals normalized by number of virtual users.</small>
+  </div>
+{{end}}
+
+{{if .PerIterationMetrics}}
+<div class="summary">
+    <h3>🔁 Per Iteration Metrics</h3>
+    <table style="margin-bottom: 20px;">
+        <tr><th>Metric</th><th>Per Iteration</th></tr>
+        {{range $name, $value := .PerIterationMetrics}}
+        <tr>
+            <td>{{stripSuffix $name "_per_iter"}}</td>
+            <td>{{printf "%.2f" $value}}</td>
+        </tr>
+        {{end}}
+    </table>
+    <small>Values represent totals normalized by iteration count.</small>
+  </div>
 {{end}}
 
 <h3>Request Details</h3>

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -485,6 +485,8 @@ func (r *Runner) execute(req chttp.Request, te *template.Engine, virtualUserId, 
 
 	// Calculate timing metrics
 	duration := gotResponse.Sub(startTime)
+	// Ensure the measured duration is recorded on the result for reporting
+	result.ResponseTime = duration
 	blocked := time.Duration(0)
 	connecting := time.Duration(0)
 	sending := time.Duration(0)


### PR DESCRIPTION
```
feat: Erweiterte Metriken im HTML-Report und Normalisierung nach VU/Iteration

**Beschreibung:**

Diese Änderung erweitert den HTML-Report um zusätzliche Metriken und ermöglicht die Normalisierung von Metriken pro virtuellem Benutzer (VU) und pro Iteration. Dies bietet detailliertere Einblicke in die Performance und das Verhalten der Anwendung unter Last.

**Motivation:**

Die bisherigen Metriken im HTML-Report waren nicht ausreichend, um ein umfassendes Bild der Performance zu erhalten. Durch die Hinzufügung neuer Metriken und die Möglichkeit der Normalisierung können Engpässe und Performance-Probleme leichter identifiziert werden. Die Normalisierung pro VU/Iteration hilft, das Verhalten einzelner Benutzer bzw. Durchläufe zu verstehen und Anomalien zu erkennen.

**Was wurde geändert:**

*   `reporting/formatters/html/formatter_html.go`: Eine neue Template-Funktion `stripSuffix` wurde hinzugefügt, um Suffixe von Metriknamen zu entfernen und die Darstellung im Report zu verbessern.
*   `reporting/formatters/html/templates/htmlTemplate.html`:
    *   Anzeige von `Virtual Users` und `Runtime` (falls vorhanden) im Summary Bereich hinzugefügt.
    *   Eine Spalte "Rate" mit zugehöriger Einheit wurde in der Tabelle für Counter-Metriken ergänzt.
    *   Zwei neue Tabellen für "Per Virtual User Metrics" und "Per Iteration Metrics" wurden hinzugefügt, um normalisierte Metriken anzuzeigen.
    *   Der Request Details Bereich wurde beibehalten.
*    `runner/runner.go`: Die Response Time wird nun explizit im `result` gespeichert um sicherzustellen, dass dieser Wert für das Reporting verfügbar ist.

**Tests:**

Es wurden keine neuen Tests geschrieben oder bestehende Tests angepasst. **Es ist dringend erforderlich, neue Tests zu schreiben, um die korrekte Funktion der neuen Metriken und der Normalisierungslogik sicherzustellen.**
```
