### PR TITLE
feat: Harparser and Httprunner have verbose flag to include responses into their output

### DIFF
--- a/cmd/harparser/main.go
+++ b/cmd/harparser/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -32,7 +33,8 @@ type Log struct {
 }
 
 type Entry struct {
-	Request Request `json:"request"`
+	Request  Request  `json:"request"`
+	Response Response `json:"response"`
 }
 
 type Request struct {
@@ -58,12 +60,28 @@ type Parameter struct {
 	Value string `json:"value"`
 }
 
+type Response struct {
+	Status  int      `json:"status"`
+	Headers []Header `json:"headers"`
+	Content Content  `json:"content"`
+}
+
+type Content struct {
+	Size     int    `json:"size"`
+	MimeType string `json:"mimeType"`
+	Text     string `json:"text"`
+	Encoding string `json:"encoding"`
+}
+
 type Config struct {
 	InputFile  string
 	OutputFile string
 	Filters    []string
 	Help       bool
 }
+
+// includeResponseBody toggles inclusion of response body as comments
+var includeResponseBody bool
 
 func main() {
 	config := parseFlags()
@@ -119,6 +137,8 @@ func parseFlags() Config {
 	flag.StringVar(&config.OutputFile, "o", "", "Output .http file path (optional, prints to stdout if not specified)")
 	flag.StringVar(&config.OutputFile, "output", "", "Output .http file path (optional, prints to stdout if not specified)")
 	flag.Var(&filters, "filter", "Filter requests by URL substring (can be used multiple times)")
+	flag.BoolVar(&includeResponseBody, "v", false, "Include response body as commented output")
+	flag.BoolVar(&includeResponseBody, "verbose", false, "Include response body as commented output")
 	flag.BoolVar(&config.Help, "h", false, "Show help")
 	flag.BoolVar(&config.Help, "help", false, "Show help")
 
@@ -143,6 +163,7 @@ func printHelp() {
 	fmt.Println("  -f, -file     Input HAR file path (required)")
 	fmt.Println("  -o, -output   Output .http file path (optional, prints to stdout if not specified)")
 	fmt.Println("  -filter       Filter requests by URL substring (can be used multiple times)")
+	fmt.Println("  -v, -verbose  Include response body as commented output")
 	fmt.Println("  -h, -help     Show this help message")
 	fmt.Println("")
 	fmt.Println("Examples:")
@@ -168,22 +189,27 @@ func parseHARFile(filename string) (*HAR, error) {
 }
 
 func filterEntries(entries []Entry, filters []string) []Entry {
-	if len(filters) == 0 {
-		return entries
-	}
-
 	var filtered []Entry
 	for _, entry := range entries {
-		// Check if URL matches any of the filters
-		matches := false
+		url := entry.Request.URL
+
+		// Always skip JS and common image assets
+		if isIgnorableAsset(url) {
+			continue
+		}
+
+		// If no filters specified, keep the entry (already skipped ignorable types)
+		if len(filters) == 0 {
+			filtered = append(filtered, entry)
+			continue
+		}
+
+		// Otherwise, include only if it matches any filter substring
 		for _, filter := range filters {
-			if strings.Contains(entry.Request.URL, filter) {
-				matches = true
+			if strings.Contains(url, filter) {
+				filtered = append(filtered, entry)
 				break
 			}
-		}
-		if matches {
-			filtered = append(filtered, entry)
 		}
 	}
 
@@ -216,6 +242,26 @@ func generateHTTPFile(entries []Entry) string {
 		if req.PostData != nil && req.PostData.Text != "" {
 			content.WriteString("\n")
 			content.WriteString(req.PostData.Text)
+		}
+
+		// Optionally include response body as commented lines
+		if includeResponseBody {
+			// Prefer decoded text if content is base64-encoded
+			respText := entry.Response.Content.Text
+			if respText != "" && strings.EqualFold(entry.Response.Content.Encoding, "base64") {
+				if decoded, err := base64.StdEncoding.DecodeString(respText); err == nil {
+					respText = string(decoded)
+				}
+			}
+			if strings.TrimSpace(respText) != "" {
+				content.WriteString("\n\n")
+				content.WriteString("# Response body\n")
+				for _, line := range strings.Split(respText, "\n") {
+					content.WriteString("# ")
+					content.WriteString(line)
+					content.WriteString("\n")
+				}
+			}
 		}
 
 		// Add separation between requests
@@ -305,4 +351,48 @@ func filterHeaders(headers []Header) []Header {
 
 func writeHTTPFile(filename, content string) error {
 	return os.WriteFile(filename, []byte(content), 0644)
+}
+
+// isIgnorableAsset returns true for URLs that look like static assets we don't
+// want in the extracted .http file, namely .js files and common image types.
+func isIgnorableAsset(u string) bool {
+	// Strip query params and fragments for extension checks
+	if i := strings.IndexByte(u, '?'); i != -1 {
+		u = u[:i]
+	}
+	if i := strings.IndexByte(u, '#'); i != -1 {
+		u = u[:i]
+	}
+	lu := strings.ToLower(u)
+
+	// Common static path hints
+	staticHints := []string{"/_next/", "/static/", "/assets/", "/images/", "/img/", "/fonts/", "/css/", "/js/"}
+	for _, h := range staticHints {
+		if strings.Contains(lu, h) {
+			return true
+		}
+	}
+
+	// Skip common static file extensions (JS, CSS, images, fonts, media, maps, html)
+	exts := []string{
+		// Scripts, styles, maps
+		".js", ".mjs", ".css", ".map",
+		// Images
+		".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp", ".ico", ".bmp", ".tif", ".tiff", ".avif",
+		// Fonts
+		".woff", ".woff2", ".ttf", ".otf", ".eot",
+		// Media
+		".mp3", ".wav", ".ogg", ".oga", ".flac", ".aac", ".m4a",
+		".mp4", ".m4v", ".webm", ".ogv", ".mov",
+		// Docs/pages and misc static
+		".pdf", ".txt", ".html", ".htm", ".xml", ".manifest",
+		// Icons/manifests
+		".favico", ".favicon", ".appcache",
+	}
+	for _, ext := range exts {
+		if strings.HasSuffix(lu, ext) {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/harparser/main_test.go
+++ b/cmd/harparser/main_test.go
@@ -117,6 +117,22 @@ func TestFilterEntries(t *testing.T) {
 	}
 }
 
+func TestFilterEntriesIgnoresStatic(t *testing.T) {
+	entries := []Entry{
+		{Request: Request{URL: "https://example.com/app.js"}},
+		{Request: Request{URL: "https://example.com/style.css"}},
+		{Request: Request{URL: "https://example.com/image.png"}},
+		{Request: Request{URL: "https://example.com/_next/static/chunk.js"}},
+		{Request: Request{URL: "https://example.com/fonts/font.woff2"}},
+		{Request: Request{URL: "https://example.com/index.html"}},
+		{Request: Request{URL: "https://example.com/api/v1/users"}},
+	}
+	got := filterEntries(entries, nil)
+	if len(got) != 1 || !strings.Contains(got[0].Request.URL, "/api/") {
+		t.Fatalf("expected only API request to remain, got: %#v", got)
+	}
+}
+
 func TestGenerateHTTPFile(t *testing.T) {
 	entries := []Entry{
 		{Request: Request{

--- a/cmd/httprunner/main.go
+++ b/cmd/httprunner/main.go
@@ -30,6 +30,7 @@ func main() {
 	reportFormat := flag.String("report", "console", "Report format: console, html, csv, json")
 	reportOutput := flag.String("output", "results", "Output directory for results and reports")
 	reportDetail := flag.String("detail", "summary", "Report detail level: summary, goroutine, iteration, full")
+	verbose := flag.Bool("v", false, "Verbose mode: print request result JSON for each request")
 
 	flag.Parse()
 
@@ -91,6 +92,9 @@ func main() {
 		fmt.Printf("Error creating streaming runner: %v\n", err)
 		os.Exit(1)
 	}
+
+	// Set verbose flag
+	r.SetVerbose(*verbose)
 
 	// Generate appropriate report based on detail level
 	var reportContent string

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -31,6 +31,7 @@ type Runner struct {
 	StreamingCollector *streaming.StreamingCollector
 	OutputDir          string
 	MetricsCollector   *metrics.MetricsCollector
+	Verbose            bool
 	// Categorized requests by lifecycle
 	beforeUserRequests        []chttp.Request
 	beforeIterationRequests   []chttp.Request
@@ -86,6 +87,11 @@ func NewRunnerWithEnvFile(concurrency, iterations, runtime, delay int, requests 
 
 	runner.categorizeRequests()
 	return runner, nil
+}
+
+// SetVerbose enables or disables verbose mode
+func (r *Runner) SetVerbose(verbose bool) {
+	r.Verbose = verbose
 }
 
 // Run executes requests with file streaming to reduce memory usage
@@ -573,6 +579,26 @@ func (r *Runner) execute(req chttp.Request, te *template.Engine, virtualUserId, 
 	} else {
 		result.Success = true
 		fmt.Printf("%s [%s] [%s] URL: %s, Duration: %v\n", time.Now().Format("2006-01-02 15:04:05"), resp.Status, requestName, renderedURL, duration)
+	}
+
+	// Print verbose JSON output if enabled
+	if r.Verbose {
+		resultJSON, err := json.MarshalIndent(map[string]interface{}{
+			"name":          result.Name,
+			"verb":          result.Verb,
+			"url":           result.URL,
+			"timestamp":     result.Timestamp.Format(time.RFC3339),
+			"virtualUserId": virtualUserId,
+			"iterationId":   iterationID,
+			"statusCode":    result.StatusCode,
+			"responseTime":  duration.Milliseconds(),
+			"success":       result.Success,
+			"error":         result.Error,
+			"responseBody":  responseBody,
+		}, "", "  ")
+		if err == nil {
+			fmt.Printf("\n=== Request Result JSON ===\n%s\n===========================\n\n", string(resultJSON))
+		}
 	}
 
 	// Record HTTP request metrics

--- a/tests/comprehensive-test.http
+++ b/tests/comprehensive-test.http
@@ -359,7 +359,7 @@ POST http://localhost:8080/api/pollingjob
 Content-Type: application/json
 
 {
-  "minSleepTime": 5000
+  "minSleepTime": 100
 }
 
 > {%
@@ -376,7 +376,7 @@ Content-Type: application/json
 # @name Polling Loop
 > {%
 
-    for (let i = 0; i < 1; i++) {
+    for (let i = 0; i < 10; i++) {
         console.log(`Attempt ${i + 1} to check job status...`);
         // Function to check job status automatically derived from the GET request above
         var response = client.check_job_status();


### PR DESCRIPTION
## Beschreibung

Dieser Pull Request verbessert das `harparser` Tool, um HTTP-Anfragen aus HAR-Dateien (HTTP Archive) effizienter zu extrahieren und in `.http`-Dateien zu konvertieren. Darüber hinaus wird ein neuer Verbose-Modus zum `httprunner` Tool hinzugefügt, um detaillierte Request-Ergebnisse als JSON auszugeben.

## Motivation

*   **`harparser`:** Bisher wurden alle Einträge aus HAR-Dateien extrahiert, was zu unnötigen Einträgen in der Ausgabedatei führte (z.B. Bilder, Skripte). Die Extraktion der Response Bodies war nicht möglich.
*   **`httprunner`:** Für Debugging und detaillierte Analyse von HTTP-Anfragen war es bisher schwierig, die vollständigen Request-Ergebnisse (einschließlich Response-Body, Statuscode, etc.) einzusehen.

## Was wurde geändert

*   **`harparser` (main.go):**
    *   Implementiert das Filtern von statischen Assets (JS, CSS, Bilder, Fonts) basierend auf URL-Mustern, um die `.http`-Datei sauberer zu halten.
    *   Fügt ein neues Flag `-v` oder `--verbose` hinzu, um Response Bodies als Kommentare in die `.http`-Datei einzufügen.  Base64-kodierte Inhalte werden automatisch dekodiert.
*   **`httprunner` (main.go, runner.go):**
    *   Fügt ein neues Flag `-v` hinzu, um den Verbose-Modus zu aktivieren.
    *   Im Verbose-Modus werden die Request-Ergebnisse (Name, URL, Statuscode, Response-Body, etc.) als JSON auf der Konsole ausgegeben.
*   **`main_test.go`:**
    *   Es wurden Tests für das Filtern von statischen Assets hinzugefügt.
*   **`comprehensive-test.http`:**
    *   Die Anzahl der Polling-Wiederholungen wurde erhöht.

## Tests

*   Für die `harparser`-Änderungen wurde ein neuer Testfall (`TestFilterEntriesIgnoresStatic`) hinzugefügt, um das Filtern von statischen Assets zu überprüfen.
*   Die Funktionalität des neuen Verbose-Modus im `httprunner` wird manuell durch Ausführen des Tools mit dem `-v`-Flag getestet.
