### PR TITLE
feat: Offline-Reports from raw results

### DIFF
--- a/cmd/httprunner/main.go
+++ b/cmd/httprunner/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/deicon/httprunner/parser"
 	"github.com/deicon/httprunner/reporting"
@@ -31,6 +32,7 @@ func main() {
 	reportOutput := flag.String("output", "results", "Output directory for results and reports")
 	reportDetail := flag.String("detail", "summary", "Report detail level: summary, goroutine, iteration, full")
 	verbose := flag.Bool("v", false, "Verbose mode: print request result JSON for each request")
+	rawFile := flag.String("raw", "", "Path to raw results .jsonl file to generate report without executing")
 
 	flag.Parse()
 
@@ -39,19 +41,23 @@ func main() {
 		return
 	}
 
-	if *requestFile == "" {
-		fmt.Println("Error: -f flag is required")
+	// Offline reporting mode: when -raw is provided, skip execution
+	offlineMode := *rawFile != ""
+	if !offlineMode && *requestFile == "" {
+		fmt.Println("Error: -f flag is required (or provide -raw to read a raw results file)")
 		os.Exit(1)
 	}
 
-	// Validate runtime vs iterations parameters
-	if *runtime < 0 {
-		fmt.Println("Error: runtime (-r) must be 0 or positive")
-		os.Exit(1)
-	}
-	if *iterations < 1 {
-		fmt.Println("Error: iterations (-i) must be positive")
-		os.Exit(1)
+	// Validate runtime vs iterations parameters (only for execution mode)
+	if !offlineMode {
+		if *runtime < 0 {
+			fmt.Println("Error: runtime (-r) must be 0 or positive")
+			os.Exit(1)
+		}
+		if *iterations < 1 {
+			fmt.Println("Error: iterations (-i) must be positive")
+			os.Exit(1)
+		}
 	}
 
 	// Validate report format
@@ -72,6 +78,73 @@ func main() {
 	default:
 		fmt.Printf("Error: Invalid report detail level '%s'. Valid levels: summary, goroutine, iteration, full\n", *reportDetail)
 		os.Exit(1)
+	}
+
+	// If offline mode, build report from raw file and exit
+	if offlineMode {
+		// Build a FileReporter on the provided raw file
+		fr := reporting.NewFileReporter(*rawFile)
+
+		var reportContent string
+		var err error
+
+		if detailLevel == types.DetailSummary {
+			rep, genErr := fr.GenerateReport(time.Time{}) // let reporter derive start/end times
+			if genErr != nil {
+				fmt.Printf("Error generating report from raw file: %v\n", genErr)
+				os.Exit(1)
+			}
+			formatter := reporting.GetFormatter(types.ReportFormat(strings.ToLower(*reportFormat)))
+			reportContent, err = formatter.Format(rep)
+		} else {
+			hr, genErr := fr.GenerateHierarchicalReport(time.Time{})
+			if genErr != nil {
+				fmt.Printf("Error generating hierarchical report from raw file: %v\n", genErr)
+				os.Exit(1)
+			}
+			hierarchicalFormatter := &hierarchical.HierarchicalFormatter{
+				DetailLevel: detailLevel,
+				Format:      types.ReportFormat(strings.ToLower(*reportFormat)),
+			}
+			reportContent, err = hierarchicalFormatter.FormatHierarchical(hr)
+		}
+
+		if err != nil {
+			fmt.Printf("Error formatting report: %v\n", err)
+			os.Exit(1)
+		}
+
+		// Output handling mirrors execution mode
+		format := types.ReportFormat(strings.ToLower(*reportFormat))
+		if format == types.FormatConsole {
+			fmt.Print(reportContent)
+		} else {
+			// Ensure output directory exists
+			if err := os.MkdirAll(*reportOutput, 0755); err != nil {
+				fmt.Printf("Error ensuring output directory: %v\n", err)
+				os.Exit(1)
+			}
+			filename := filepath.Join(*reportOutput, "report")
+			switch format {
+			case types.FormatHTML:
+				filename += ".html"
+			case types.FormatCSV:
+				filename += ".csv"
+			case types.FormatJSON:
+				filename += ".json"
+			default:
+				filename += ".txt"
+			}
+			if err := os.WriteFile(filename, []byte(reportContent), 0644); err != nil {
+				fmt.Printf("Error writing report to file: %v\n", err)
+				os.Exit(1)
+			}
+			fmt.Printf("\nFormatted report saved to: %s\n", filename)
+		}
+
+		// In offline mode, also echo the raw file path for convenience
+		fmt.Printf("Raw results used: %s\n", *rawFile)
+		return
 	}
 
 	requests, err := parser.Parse(*requestFile)

--- a/reporting/file_reporter.go
+++ b/reporting/file_reporter.go
@@ -45,7 +45,7 @@ func (fr *FileReporter) generateReportStreaming(startTime time.Time) (*types.Rep
 		CheckSummaries:           make(map[string]types.CheckSummary),
 		RequestDetails:           make([]types.RequestResult, 0),
 		StartTime:                startTime,
-		EndTime:                  time.Now(),
+		EndTime:                  time.Time{},
 		MinResponseTime:          time.Hour, // Initialize to high value
 		MaxResponseTime:          0,
 		MetricsSummaries:         make(map[string]metrics.MetricSummary),
@@ -53,6 +53,12 @@ func (fr *FileReporter) generateReportStreaming(startTime time.Time) (*types.Rep
 
 	scanner := bufio.NewScanner(file)
 	var totalResponseTime time.Duration
+	// Track first/last timestamps and durations to compute offline metrics
+	var firstTimestamp time.Time
+	var lastTimestamp time.Time
+	durationsMs := make([]float64, 0, 1024)
+	// Track unique virtual users
+	vus := make(map[int]struct{})
 
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -69,6 +75,9 @@ func (fr *FileReporter) generateReportStreaming(startTime time.Time) (*types.Rep
 		report.TotalRequests++
 		totalResponseTime += result.ResponseTime
 
+		// Track VU set
+		vus[result.VirtualUserID] = struct{}{}
+
 		if result.Success {
 			report.SuccessfulRequests++
 		} else {
@@ -77,6 +86,17 @@ func (fr *FileReporter) generateReportStreaming(startTime time.Time) (*types.Rep
 				report.ErrorBreakdown[result.Error]++
 			}
 		}
+
+		// Track timestamps for runtime
+		if firstTimestamp.IsZero() || result.Timestamp.Before(firstTimestamp) {
+			firstTimestamp = result.Timestamp
+		}
+		if lastTimestamp.IsZero() || result.Timestamp.After(lastTimestamp) {
+			lastTimestamp = result.Timestamp
+		}
+
+		// Collect durations (ms) for trend metrics
+		durationsMs = append(durationsMs, float64(result.ResponseTime.Milliseconds()))
 
 		// Update min/max response times
 		if result.ResponseTime < report.MinResponseTime {
@@ -153,6 +173,93 @@ func (fr *FileReporter) generateReportStreaming(startTime time.Time) (*types.Rep
 		report.MinResponseTime = 0
 	}
 
+	// Derive start/end time and runtime if possible
+	if !firstTimestamp.IsZero() {
+		// Prefer provided startTime if non-zero, otherwise infer from first record
+		if !startTime.IsZero() {
+			report.StartTime = startTime
+		} else {
+			report.StartTime = firstTimestamp
+		}
+		// End at last observed timestamp
+		report.EndTime = lastTimestamp
+		if report.EndTime.After(report.StartTime) {
+			report.RuntimeSeconds = report.EndTime.Sub(report.StartTime).Seconds()
+		}
+	}
+
+	// Derive total virtual users from observed results
+	report.TotalVirtualUsers = len(vus)
+
+	// Populate key metrics summaries for offline reports
+	if report.MetricsSummaries == nil {
+		report.MetricsSummaries = make(map[string]metrics.MetricSummary)
+	}
+
+	// http_reqs counter with rate
+	if report.TotalRequests > 0 {
+		httpReqs := metrics.MetricSummary{
+			Name:  "http_reqs",
+			Type:  metrics.Counter,
+			Count: report.TotalRequests,
+			Sum:   float64(report.TotalRequests),
+		}
+		if report.RuntimeSeconds > 0 {
+			httpReqs.Rate = httpReqs.Sum / report.RuntimeSeconds
+			httpReqs.RateUnit = "req/s"
+		}
+		report.MetricsSummaries["http_reqs"] = httpReqs
+	}
+
+	// http_req_failed rate (average failure ratio)
+	if report.TotalRequests > 0 {
+		httpReqFailed := metrics.MetricSummary{
+			Name:    "http_req_failed",
+			Type:    metrics.Rate,
+			Count:   report.TotalRequests,
+			Sum:     float64(report.FailedRequests),
+			Average: float64(report.FailedRequests) / float64(report.TotalRequests),
+		}
+		report.MetricsSummaries["http_req_failed"] = httpReqFailed
+	}
+
+	// http_req_duration trend (ms)
+	if len(durationsMs) > 0 {
+		// Compute stats
+		sort.Float64s(durationsMs)
+		var sum float64
+		for _, v := range durationsMs {
+			sum += v
+		}
+		count := len(durationsMs)
+		durationSummary := metrics.MetricSummary{
+			Name:    "http_req_duration",
+			Type:    metrics.Trend,
+			Count:   count,
+			Sum:     sum,
+			Average: sum / float64(count),
+			Min:     durationsMs[0],
+			Max:     durationsMs[count-1],
+			P50:     percentile(durationsMs, 50),
+			P90:     percentile(durationsMs, 90),
+			P95:     percentile(durationsMs, 95),
+			P99:     percentile(durationsMs, 99),
+		}
+		report.MetricsSummaries["http_req_duration"] = durationSummary
+	}
+
+	// checks rate (average success ratio)
+	if report.TotalChecks > 0 {
+		checks := metrics.MetricSummary{
+			Name:    "checks",
+			Type:    metrics.Rate,
+			Count:   report.TotalChecks,
+			Sum:     float64(report.SuccessfulChecks),
+			Average: float64(report.SuccessfulChecks) / float64(report.TotalChecks),
+		}
+		report.MetricsSummaries["checks"] = checks
+	}
+
 	return report, nil
 }
 
@@ -171,6 +278,9 @@ func (fr *FileReporter) generateHierarchicalReportStreaming(startTime time.Time)
 
 	// Build summary report from collected data
 	summaryReport := fr.buildSummaryFromData(summaryData, startTime)
+
+	// Enrich summary with runtime and key metrics derived from request details
+	fr.enrichSummaryWithOfflineMetrics(&summaryReport)
 
 	// Build hierarchical report from goroutine data
 	hierarchical := &types.HierarchicalReport{
@@ -425,6 +535,123 @@ func (fr *FileReporter) buildSummaryFromData(summary *summaryData, startTime tim
 	}
 
 	return report
+}
+
+// enrichSummaryWithOfflineMetrics computes Start/End/Runtime and key metric summaries
+// from the report's RequestDetails, for use when generating reports from raw results.
+func (fr *FileReporter) enrichSummaryWithOfflineMetrics(report *types.Report) {
+	if len(report.RequestDetails) == 0 {
+		return
+	}
+	// Infer start/end from timestamps if available
+	var firstTS time.Time
+	var lastTS time.Time
+	durations := make([]float64, 0, len(report.RequestDetails))
+	for _, r := range report.RequestDetails {
+		if firstTS.IsZero() || r.Timestamp.Before(firstTS) {
+			firstTS = r.Timestamp
+		}
+		if lastTS.IsZero() || r.Timestamp.After(lastTS) {
+			lastTS = r.Timestamp
+		}
+		durations = append(durations, float64(r.ResponseTime.Milliseconds()))
+	}
+	if report.StartTime.IsZero() {
+		report.StartTime = firstTS
+	}
+	if !lastTS.IsZero() {
+		report.EndTime = lastTS
+	}
+	if report.EndTime.After(report.StartTime) {
+		report.RuntimeSeconds = report.EndTime.Sub(report.StartTime).Seconds()
+	}
+
+	if report.MetricsSummaries == nil {
+		report.MetricsSummaries = make(map[string]metrics.MetricSummary)
+	}
+
+	// http_reqs
+	if report.TotalRequests > 0 {
+		httpReqs := metrics.MetricSummary{
+			Name:  "http_reqs",
+			Type:  metrics.Counter,
+			Count: report.TotalRequests,
+			Sum:   float64(report.TotalRequests),
+		}
+		if report.RuntimeSeconds > 0 {
+			httpReqs.Rate = httpReqs.Sum / report.RuntimeSeconds
+			httpReqs.RateUnit = "req/s"
+		}
+		report.MetricsSummaries["http_reqs"] = httpReqs
+	}
+
+	// http_req_failed
+	if report.TotalRequests > 0 {
+		httpReqFailed := metrics.MetricSummary{
+			Name:    "http_req_failed",
+			Type:    metrics.Rate,
+			Count:   report.TotalRequests,
+			Sum:     float64(report.FailedRequests),
+			Average: float64(report.FailedRequests) / float64(report.TotalRequests),
+		}
+		report.MetricsSummaries["http_req_failed"] = httpReqFailed
+	}
+
+	// http_req_duration
+	if len(durations) > 0 {
+		sort.Float64s(durations)
+		var sum float64
+		for _, v := range durations {
+			sum += v
+		}
+		count := len(durations)
+		report.MetricsSummaries["http_req_duration"] = metrics.MetricSummary{
+			Name:    "http_req_duration",
+			Type:    metrics.Trend,
+			Count:   count,
+			Sum:     sum,
+			Average: sum / float64(count),
+			Min:     durations[0],
+			Max:     durations[count-1],
+			P50:     percentile(durations, 50),
+			P90:     percentile(durations, 90),
+			P95:     percentile(durations, 95),
+			P99:     percentile(durations, 99),
+		}
+	}
+
+	// checks
+	if report.TotalChecks > 0 {
+		report.MetricsSummaries["checks"] = metrics.MetricSummary{
+			Name:    "checks",
+			Type:    metrics.Rate,
+			Count:   report.TotalChecks,
+			Sum:     float64(report.SuccessfulChecks),
+			Average: float64(report.SuccessfulChecks) / float64(report.TotalChecks),
+		}
+	}
+}
+
+// percentile calculates an approximate percentile value from a sorted slice
+func percentile(sorted []float64, p float64) float64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	// Clamp p
+	if p < 0 {
+		p = 0
+	}
+	if p > 100 {
+		p = 100
+	}
+	idx := int(p / 100.0 * float64(len(sorted)-1))
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	return sorted[idx]
 }
 
 // buildGoroutineReportFromDataWithResults builds a goroutine report from collected data including request results

--- a/reporting/formatters/html/formatter_html.go
+++ b/reporting/formatters/html/formatter_html.go
@@ -18,8 +18,15 @@ var htmlTemplate string
 
 func (f *HTMLFormatter) Format(report *types.Report) (string, error) {
 	tmpl, err := template.New("report").Funcs(template.FuncMap{
-		"add":         func(a, b int) int { return a + b },
-		"mul":         func(a, b float64) float64 { return a * b },
+		"add": func(a, b int) int { return a + b },
+		"mul": func(a, b float64) float64 { return a * b },
+		"div": func(a, b float64) float64 {
+			if b == 0 {
+				return 0
+			}
+			return a / b
+		},
+		"float64":     func(i int) float64 { return float64(i) },
 		"stripSuffix": func(s, suffix string) string { return strings.TrimSuffix(s, suffix) },
 	}).Parse(htmlTemplate)
 	if err != nil {

--- a/reporting/formatters/html/templates/htmlTemplate.html
+++ b/reporting/formatters/html/templates/htmlTemplate.html
@@ -23,6 +23,7 @@
     <div class="metric"><strong>Successful:</strong> <span class="success">{{.SuccessfulRequests}}</span></div>
     <div class="metric"><strong>Failed:</strong> <span class="error">{{.FailedRequests}}</span></div>
     <div class="metric"><strong>Success Rate:</strong> {{printf "%.1f" .SuccessRate}}%</div>
+    <div class="metric"><strong>Requests/sec:</strong> {{if gt .RuntimeSeconds 0.0}}{{printf "%.1f" (div (float64 .TotalRequests) .RuntimeSeconds)}}{{else}}-{{end}}</div>
 </div>
 
 <div class="summary">


### PR DESCRIPTION
## PR-Beschreibung: Offline-Report-Generierung aus Rohdaten (JSONL)

### Beschreibung:
Diese Änderung ermöglicht die Generierung von Reports aus bereits vorhandenen Rohdaten im JSONL-Format, ohne dass eine erneute Ausführung der Tests erforderlich ist. Dies ist nützlich für die Analyse von Ergebnissen in einer Offline-Umgebung, zur nachträglichen Erstellung von Reports oder zur Weiterverarbeitung von Daten aus anderen Quellen.

### Motivation:
Bisher war die Generierung von Reports ausschließlich an die direkte Ausführung von HTTP-Anfragen gebunden. Dies schränkte die Flexibilität bei der Analyse von Testergebnissen ein. Die Möglichkeit, Reports aus Rohdaten zu erstellen, eröffnet neue Anwendungsfälle und verbessert die Usability des Tools.

### Was wurde geändert:
*   **`cmd/httprunner/main.go`**:
    *   Hinzufügung des Flags `-raw`, das den Pfad zu einer JSONL-Datei mit Rohdaten angibt.
    *   Implementierung eines "Offline-Modus", der aktiviert wird, wenn das `-raw`-Flag gesetzt ist. In diesem Modus werden die Requests nicht ausgeführt, sondern der Report stattdessen aus der angegebenen Datei generiert.
    *   Logik zur Validierung der Parameter wurde angepasst, um den Offline-Modus zu berücksichtigen.
    *   Ausgabe des Pfades zur verwendeten Rohdatendatei für mehr Transparenz.
*   **`reporting/file_reporter.go`**:
    *   Implementierung der `generateReportStreaming` und `generateHierarchicalReportStreaming` Methoden, um Reports direkt aus der JSONL-Datei zu generieren.
    *   Berechnung von Metriken wie Startzeit, Endzeit, Laufzeit, Requests pro Sekunde und Erfolgsraten aus den vorhandenen Request-Details.
*   **`reporting/formatters/html/formatter_html.go`**:
    *   Hinzufügung der `div` Funktion im HTML-Template, um die Division durch Null zu verhindern.
*   **`reporting/formatters/html/templates/htmlTemplate.html`**:
    *   Anpassung der Anzeige für Requests/sec, um den Fall einer Laufzeit von 0 zu berücksichtigen.

### Tests:
Es wurden keine neuen Tests geschrieben oder bestehende angepasst. **Dies ist eine kritische Warnung: Die neue Funktionalität sollte unbedingt durch Unit- und Integrationstests abgesichert werden, um die Korrektheit der Report-Generierung aus Rohdaten zu gewährleisten.** Insbesondere sollten Tests für folgende Szenarien implementiert werden:
*   Korrekte Generierung von Reports aus verschiedenen JSONL-Dateien mit unterschiedlichen Inhalten (erfolgreiche, fehlgeschlagene Requests, unterschiedliche Antwortzeiten, etc.).
*   Korrekte Berechnung der Metriken (Startzeit, Endzeit, Laufzeit, Requests pro Sekunde, Erfolgsraten, etc.).
*   Behandlung von fehlerhaften JSONL-Dateien.

