### PR TITLE
feat: Top 5 der längsten Requests im Report anzeigen

### DIFF
--- a/reporting/file_reporter.go
+++ b/reporting/file_reporter.go
@@ -44,6 +44,7 @@ func (fr *FileReporter) generateReportStreaming(startTime time.Time) (*types.Rep
 		ErrorBreakdown:           make(map[string]int),
 		CheckSummaries:           make(map[string]types.CheckSummary),
 		RequestDetails:           make([]types.RequestResult, 0),
+		TopLongestRequests:       make([]types.RequestResult, 0),
 		StartTime:                startTime,
 		EndTime:                  time.Time{},
 		MinResponseTime:          time.Hour, // Initialize to high value
@@ -258,6 +259,21 @@ func (fr *FileReporter) generateReportStreaming(startTime time.Time) (*types.Rep
 			Average: float64(report.SuccessfulChecks) / float64(report.TotalChecks),
 		}
 		report.MetricsSummaries["checks"] = checks
+	}
+
+	// Compute Top 5 Longest Requests by ResponseTime
+	if len(report.RequestDetails) > 0 {
+		// Copy slice to avoid mutating original order
+		copied := make([]types.RequestResult, len(report.RequestDetails))
+		copy(copied, report.RequestDetails)
+		sort.Slice(copied, func(i, j int) bool {
+			return copied[i].ResponseTime > copied[j].ResponseTime
+		})
+		limit := 5
+		if len(copied) < limit {
+			limit = len(copied)
+		}
+		report.TopLongestRequests = copied[:limit]
 	}
 
 	return report, nil
@@ -511,23 +527,24 @@ func (fr *FileReporter) updateGoroutineData(goroutines map[int]*goroutineData, r
 
 // buildSummaryFromData builds a summary report from collected data
 func (fr *FileReporter) buildSummaryFromData(summary *summaryData, startTime time.Time) types.Report {
-	report := types.Report{
-		TotalRequests:            summary.totalRequests,
-		SuccessfulRequests:       summary.successfulRequests,
-		FailedRequests:           summary.failedRequests,
-		MinResponseTime:          summary.minResponseTime,
-		MaxResponseTime:          summary.maxResponseTime,
-		ResponseTimeDistribution: summary.responseTimeDistribution,
-		ErrorBreakdown:           summary.errorBreakdown,
-		CheckSummaries:           summary.checkSummaries,
-		TotalChecks:              summary.totalChecks,
-		SuccessfulChecks:         summary.successfulChecks,
-		FailedChecks:             summary.failedChecks,
-		RequestDetails:           summary.requestDetails,
-		StartTime:                startTime,
-		EndTime:                  time.Now(),
-		MetricsSummaries:         make(map[string]metrics.MetricSummary),
-	}
+    report := types.Report{
+        TotalRequests:            summary.totalRequests,
+        SuccessfulRequests:       summary.successfulRequests,
+        FailedRequests:           summary.failedRequests,
+        MinResponseTime:          summary.minResponseTime,
+        MaxResponseTime:          summary.maxResponseTime,
+        ResponseTimeDistribution: summary.responseTimeDistribution,
+        ErrorBreakdown:           summary.errorBreakdown,
+        CheckSummaries:           summary.checkSummaries,
+        TotalChecks:              summary.totalChecks,
+        SuccessfulChecks:         summary.successfulChecks,
+        FailedChecks:             summary.failedChecks,
+        RequestDetails:           summary.requestDetails,
+        TopLongestRequests:       make([]types.RequestResult, 0),
+        StartTime:                startTime,
+        EndTime:                  time.Now(),
+        MetricsSummaries:         make(map[string]metrics.MetricSummary),
+    }
 
 	// Calculate average response time
 	if report.TotalRequests > 0 {
@@ -540,9 +557,9 @@ func (fr *FileReporter) buildSummaryFromData(summary *summaryData, startTime tim
 // enrichSummaryWithOfflineMetrics computes Start/End/Runtime and key metric summaries
 // from the report's RequestDetails, for use when generating reports from raw results.
 func (fr *FileReporter) enrichSummaryWithOfflineMetrics(report *types.Report) {
-	if len(report.RequestDetails) == 0 {
-		return
-	}
+    if len(report.RequestDetails) == 0 {
+        return
+    }
 	// Infer start/end from timestamps if available
 	var firstTS time.Time
 	var lastTS time.Time
@@ -566,9 +583,9 @@ func (fr *FileReporter) enrichSummaryWithOfflineMetrics(report *types.Report) {
 		report.RuntimeSeconds = report.EndTime.Sub(report.StartTime).Seconds()
 	}
 
-	if report.MetricsSummaries == nil {
-		report.MetricsSummaries = make(map[string]metrics.MetricSummary)
-	}
+    if report.MetricsSummaries == nil {
+        report.MetricsSummaries = make(map[string]metrics.MetricSummary)
+    }
 
 	// http_reqs
 	if report.TotalRequests > 0 {
@@ -621,14 +638,28 @@ func (fr *FileReporter) enrichSummaryWithOfflineMetrics(report *types.Report) {
 	}
 
 	// checks
-	if report.TotalChecks > 0 {
-		report.MetricsSummaries["checks"] = metrics.MetricSummary{
-			Name:    "checks",
-			Type:    metrics.Rate,
-			Count:   report.TotalChecks,
-			Sum:     float64(report.SuccessfulChecks),
-			Average: float64(report.SuccessfulChecks) / float64(report.TotalChecks),
+    if report.TotalChecks > 0 {
+        report.MetricsSummaries["checks"] = metrics.MetricSummary{
+            Name:    "checks",
+            Type:    metrics.Rate,
+            Count:   report.TotalChecks,
+            Sum:     float64(report.SuccessfulChecks),
+            Average: float64(report.SuccessfulChecks) / float64(report.TotalChecks),
+        }
+    }
+
+	// Compute Top 5 Longest Requests by ResponseTime
+	if len(report.RequestDetails) > 0 {
+		copied := make([]types.RequestResult, len(report.RequestDetails))
+		copy(copied, report.RequestDetails)
+		sort.Slice(copied, func(i, j int) bool {
+			return copied[i].ResponseTime > copied[j].ResponseTime
+		})
+		limit := 5
+		if len(copied) < limit {
+			limit = len(copied)
 		}
+		report.TopLongestRequests = copied[:limit]
 	}
 }
 

--- a/reporting/formatters/console/formatter_console.go
+++ b/reporting/formatters/console/formatter_console.go
@@ -41,6 +41,25 @@ func (f *ConsoleFormatter) Format(report *types.Report) (string, error) {
 	buf.WriteString(fmt.Sprintf("Maximum Response Time: %v\n", report.MaxResponseTime))
 	buf.WriteString(fmt.Sprintf("Total Duration: %v\n\n", report.EndTime.Sub(report.StartTime)))
 
+	// Top longest requests
+	if len(report.TopLongestRequests) > 0 {
+		buf.WriteString("Top 5 Longest Requests:\n")
+		limit := 5
+		if len(report.TopLongestRequests) < limit {
+			limit = len(report.TopLongestRequests)
+		}
+		for i := 0; i < limit; i++ {
+			req := report.TopLongestRequests[i]
+			status := fmt.Sprintf("%d ✓", req.StatusCode)
+			if !req.Success {
+				status = fmt.Sprintf("ERROR: %s", req.Error)
+			}
+			buf.WriteString(fmt.Sprintf("  %d. %s %s %s  %s  %.3f ms  (VU %d, Iter %d)\n",
+				i+1, req.Verb, req.Name, req.URL, status, float64(req.ResponseTime.Nanoseconds())/1e6, req.VirtualUserID, req.IterationID))
+		}
+		buf.WriteString("\n")
+	}
+
 	// Response time distribution
 	if len(report.ResponseTimeDistribution) > 0 {
 		buf.WriteString("Response Time Distribution:\n")

--- a/reporting/formatters/hierarchical/hierarchical.go
+++ b/reporting/formatters/hierarchical/hierarchical.go
@@ -34,7 +34,7 @@ func (f *HierarchicalFormatter) FormatHierarchical(report *types.HierarchicalRep
 }
 
 func (f *HierarchicalFormatter) formatHierarchicalConsole(report *types.HierarchicalReport) (string, error) {
-	var buf bytes.Buffer
+    var buf bytes.Buffer
 
 	// Always show summary
 	buf.WriteString("HTTP Request Report - Summary\n")
@@ -57,8 +57,27 @@ func (f *HierarchicalFormatter) formatHierarchicalConsole(report *types.Hierarch
 		buf.WriteString(fmt.Sprintf("Request Success Rate: %.1f%%\n", successRate))
 	}
 
-	buf.WriteString(fmt.Sprintf("Average Response Time: %v\n", report.Summary.AverageResponseTime))
-	buf.WriteString(fmt.Sprintf("Total Duration: %v\n\n", report.Summary.EndTime.Sub(report.Summary.StartTime)))
+    buf.WriteString(fmt.Sprintf("Average Response Time: %v\n", report.Summary.AverageResponseTime))
+    buf.WriteString(fmt.Sprintf("Total Duration: %v\n\n", report.Summary.EndTime.Sub(report.Summary.StartTime)))
+
+    // Top longest requests (from summary)
+    if len(report.Summary.TopLongestRequests) > 0 {
+        buf.WriteString("Top 5 Longest Requests:\n")
+        limit := 5
+        if len(report.Summary.TopLongestRequests) < limit {
+            limit = len(report.Summary.TopLongestRequests)
+        }
+        for i := 0; i < limit; i++ {
+            req := report.Summary.TopLongestRequests[i]
+            status := fmt.Sprintf("%d ✓", req.StatusCode)
+            if !req.Success {
+                status = fmt.Sprintf("ERROR: %s", req.Error)
+            }
+            buf.WriteString(fmt.Sprintf("  %d. %s %s %s  %s  %.3f ms  (VU %d, Iter %d)\n",
+                i+1, req.Verb, req.Name, req.URL, status, float64(req.ResponseTime.Nanoseconds())/1e6, req.VirtualUserID, req.IterationID))
+        }
+        buf.WriteString("\n")
+    }
 
 	// Check results summary
 	if len(report.Summary.CheckSummaries) > 0 {
@@ -244,21 +263,22 @@ func (f *HierarchicalFormatter) formatHierarchicalConsole(report *types.Hierarch
 }
 
 func (f *HierarchicalFormatter) formatHierarchicalJSON(report *types.HierarchicalReport) (string, error) {
-	// Create structured JSON based on detail level
-	output := map[string]interface{}{
-		"summary": map[string]interface{}{
-			"totalGoroutines":      report.TotalVirtualUsers,
-			"successfulGoroutines": report.SuccessfulVirtualUsers,
-			"failedGoroutines":     report.FailedVirtualUsers,
-			"totalRequests":        report.Summary.TotalRequests,
-			"successfulRequests":   report.Summary.SuccessfulRequests,
-			"failedRequests":       report.Summary.FailedRequests,
-			"averageResponseTime":  report.Summary.AverageResponseTime.String(),
-			"totalDuration":        report.Summary.EndTime.Sub(report.Summary.StartTime).String(),
-			"startTime":            report.Summary.StartTime.Format(time.RFC3339),
-			"endTime":              report.Summary.EndTime.Format(time.RFC3339),
-		},
-	}
+    // Create structured JSON based on detail level
+    output := map[string]interface{}{
+        "summary": map[string]interface{}{
+            "totalGoroutines":      report.TotalVirtualUsers,
+            "successfulGoroutines": report.SuccessfulVirtualUsers,
+            "failedGoroutines":     report.FailedVirtualUsers,
+            "totalRequests":        report.Summary.TotalRequests,
+            "successfulRequests":   report.Summary.SuccessfulRequests,
+            "failedRequests":       report.Summary.FailedRequests,
+            "averageResponseTime":  report.Summary.AverageResponseTime.String(),
+            "totalDuration":        report.Summary.EndTime.Sub(report.Summary.StartTime).String(),
+            "startTime":            report.Summary.StartTime.Format(time.RFC3339),
+            "endTime":              report.Summary.EndTime.Format(time.RFC3339),
+            "topLongestRequests":   report.Summary.TopLongestRequests,
+        },
+    }
 
 	if f.DetailLevel == types.DetailVirtualuser || f.DetailLevel == types.DetailIteration || f.DetailLevel == types.DetailFull {
 		goroutines := make([]map[string]interface{}, 0, len(report.VirtualUserReports))

--- a/reporting/formatters/hierarchical/templates/hierarchicalHTMLTemplate.html
+++ b/reporting/formatters/hierarchical/templates/hierarchicalHTMLTemplate.html
@@ -243,6 +243,26 @@
 </div>
 </div>
 
+{{if .Summary.TopLongestRequests}}
+<div class="summary">
+    <h2>⏱️ Top 5 Longest Requests</h2>
+    <table>
+        <tr><th>#</th><th>Method</th><th>Name</th><th>URL</th><th>Status</th><th>Time</th><th>Iteration</th></tr>
+        {{range $i, $req := .Summary.TopLongestRequests}}
+        <tr>
+            <td>{{add $i 1}}</td>
+            <td>{{$req.Verb}}</td>
+            <td>{{$req.Name}}</td>
+            <td class="url" title="{{$req.URL}}">{{$req.URL}}</td>
+            <td>{{if $req.Success}}<span class="success">{{$req.StatusCode}} ✓</span>{{else}}<span class="error">{{$req.StatusCode}} ✗</span>{{end}}</td>
+            <td>{{$req.ResponseTime}}</td>
+            <td><a href="#iter-vu-{{$req.VirtualUserID}}-{{$req.IterationID}}">VU {{$req.VirtualUserID}}, Iter {{$req.IterationID}}</a></td>
+        </tr>
+        {{end}}
+    </table>
+</div>
+{{end}}
+
 {{if gt .Summary.TotalChecks 0}}
 <div class="summary">
     <h2>✅ Check Results</h2>
@@ -322,7 +342,7 @@
         </button>
         <div class="content">
             {{range $iterationIndex, $iteration := $goroutine.Iterations}}
-            <div class="iteration-header">
+            <div class="iteration-header" id="iter-vu-{{$goroutine.GoroutineID}}-{{$iteration.IterationID}}">
                 <strong>Iteration {{$iteration.IterationID}}</strong>
                 - {{$iteration.TotalRequests}} requests
                 - {{if gt $iteration.TotalRequests 0}}{{printf "%.1f" (mul (div (float64 $iteration.SuccessfulRequests) (float64 $iteration.TotalRequests)) 100.0)}}%{{else}}0%{{end}} success

--- a/reporting/formatters/html/templates/htmlTemplate.html
+++ b/reporting/formatters/html/templates/htmlTemplate.html
@@ -39,6 +39,28 @@
     {{end}}
 </div>
 
+{{if .TopLongestRequests}}
+<div class="summary">
+    <h3>⏱️ Top 5 Longest Requests</h3>
+    <table style="margin-bottom: 10px;">
+        <tr><th>#</th><th>Method</th><th>Name</th><th>URL</th><th>Status</th><th>Time</th><th>VU</th><th>Iter</th></tr>
+        {{range $i, $req := .TopLongestRequests}}
+        <tr>
+            <td>{{add $i 1}}</td>
+            <td>{{$req.Verb}}</td>
+            <td>{{$req.Name}}</td>
+            <td>{{$req.URL}}</td>
+            <td>{{if $req.Success}}<span class="success">{{$req.StatusCode}} ✓</span>{{else}}<span class="error">{{$req.StatusCode}} ✗</span>{{end}}</td>
+            <td>{{$req.ResponseTime}}</td>
+            <td>{{$req.VirtualUserID}}</td>
+            <td>{{$req.IterationID}}</td>
+        </tr>
+        {{end}}
+    </table>
+    <small>Tip: Use the hierarchical HTML report for direct links to iterations.</small>
+  </div>
+{{end}}
+
 {{if .ResponseTimeDistribution}}
 <div class="chart">
     <div class="distribution">
@@ -198,7 +220,7 @@
         <th>Timestamp</th>
     </tr>
     {{range $index, $req := .RequestDetails}}
-    <tr>
+    <tr id="req-vu-{{$req.VirtualUserID}}-iter-{{$req.IterationID}}-{{$index}}">
         <td>{{add $index 1}}</td>
         <td>{{$req.Name}}</td>
         <td>{{$req.Verb}}</td>

--- a/reporting/formatters/json/formatter_json.go
+++ b/reporting/formatters/json/formatter_json.go
@@ -11,35 +11,36 @@ import (
 type JSONFormatter struct{}
 
 func (f *JSONFormatter) Format(report *types.Report) (string, error) {
-	// Create a more structured JSON output
-	output := map[string]interface{}{
-		"summary": map[string]interface{}{
-			"totalRequests":       report.TotalRequests,
-			"successfulRequests":  report.SuccessfulRequests,
-			"failedRequests":      report.FailedRequests,
-			"successRate":         0.0,
-			"totalChecks":         report.TotalChecks,
-			"successfulChecks":    report.SuccessfulChecks,
-			"failedChecks":        report.FailedChecks,
-			"checkSuccessRate":    0.0,
-			"totalVirtualUsers":   report.TotalVirtualUsers,
-			"runtimeSeconds":      report.RuntimeSeconds,
-			"requestsPerSecond":   0.0,
-			"averageResponseTime": report.AverageResponseTime.String(),
-			"minResponseTime":     report.MinResponseTime.String(),
-			"maxResponseTime":     report.MaxResponseTime.String(),
-			"totalDuration":       report.EndTime.Sub(report.StartTime).String(),
-			"startTime":           report.StartTime.Format(time.RFC3339),
-			"endTime":             report.EndTime.Format(time.RFC3339),
-		},
-		"responseTimeDistribution": report.ResponseTimeDistribution,
-		"errorBreakdown":           report.ErrorBreakdown,
-		"checkSummaries":           report.CheckSummaries,
-		"metricsSummaries":         report.MetricsSummaries,
-		"perVUMetrics":             report.PerVUMetrics,
-		"perIterationMetrics":      report.PerIterationMetrics,
-		"requestDetails":           report.RequestDetails,
-	}
+    // Create a more structured JSON output
+    output := map[string]interface{}{
+        "summary": map[string]interface{}{
+            "totalRequests":       report.TotalRequests,
+            "successfulRequests":  report.SuccessfulRequests,
+            "failedRequests":      report.FailedRequests,
+            "successRate":         0.0,
+            "totalChecks":         report.TotalChecks,
+            "successfulChecks":    report.SuccessfulChecks,
+            "failedChecks":        report.FailedChecks,
+            "checkSuccessRate":    0.0,
+            "totalVirtualUsers":   report.TotalVirtualUsers,
+            "runtimeSeconds":      report.RuntimeSeconds,
+            "requestsPerSecond":   0.0,
+            "averageResponseTime": report.AverageResponseTime.String(),
+            "minResponseTime":     report.MinResponseTime.String(),
+            "maxResponseTime":     report.MaxResponseTime.String(),
+            "totalDuration":       report.EndTime.Sub(report.StartTime).String(),
+            "startTime":           report.StartTime.Format(time.RFC3339),
+            "endTime":             report.EndTime.Format(time.RFC3339),
+            "topLongestRequests":  report.TopLongestRequests,
+        },
+        "responseTimeDistribution": report.ResponseTimeDistribution,
+        "errorBreakdown":           report.ErrorBreakdown,
+        "checkSummaries":           report.CheckSummaries,
+        "metricsSummaries":         report.MetricsSummaries,
+        "perVUMetrics":             report.PerVUMetrics,
+        "perIterationMetrics":      report.PerIterationMetrics,
+        "requestDetails":           report.RequestDetails,
+    }
 
 	if report.TotalRequests > 0 {
 		output["summary"].(map[string]interface{})["successRate"] = float64(report.SuccessfulRequests) / float64(report.TotalRequests) * 100

--- a/reporting/types/types.go
+++ b/reporting/types/types.go
@@ -40,20 +40,23 @@ type RequestResult struct {
 
 // Report contains aggregated statistics from all request executions
 type Report struct {
-	TotalRequests            int
-	SuccessfulRequests       int
-	FailedRequests           int
-	AverageResponseTime      time.Duration
-	MinResponseTime          time.Duration
-	MaxResponseTime          time.Duration
-	ResponseTimeDistribution map[string]int
-	ErrorBreakdown           map[string]int
-	RequestDetails           []RequestResult
-	StartTime                time.Time
-	EndTime                  time.Time
-	CheckSummaries           map[string]CheckSummary
-	TotalChecks              int
-	SuccessfulChecks         int
+    TotalRequests            int
+    SuccessfulRequests       int
+    FailedRequests           int
+    AverageResponseTime      time.Duration
+    MinResponseTime          time.Duration
+    MaxResponseTime          time.Duration
+    ResponseTimeDistribution map[string]int
+    ErrorBreakdown           map[string]int
+    RequestDetails           []RequestResult
+    // TopLongestRequests contains the top N requests by ResponseTime (descending)
+    // This helps identify the longest-running calls quickly in reports.
+    TopLongestRequests       []RequestResult
+    StartTime                time.Time
+    EndTime                  time.Time
+    CheckSummaries           map[string]CheckSummary
+    TotalChecks              int
+    SuccessfulChecks         int
 	FailedChecks             int
 	MetricsSummaries         map[string]metrics.MetricSummary
 	TotalVirtualUsers        int


### PR DESCRIPTION
feat: Top 5 der längsten Requests im Report anzeigen

Beschreibung:
Diese Änderung erweitert die Reporting-Funktionalität, um die Top 5 der längsten Requests (gemessen an der Antwortzeit) in den generierten Reports anzuzeigen.  Dies hilft Benutzern, Performance-Engpässe schnell zu identifizieren.

Motivation:
Die Identifizierung von langsamen Requests ist entscheidend für die Performance-Analyse und -Optimierung.  Bisherige Reports haben diese Information nicht direkt bereitgestellt, was die Fehlersuche erschwert hat.  Diese Änderung soll diese Lücke schließen und einen schnellen Überblick über die leistungsschwächsten Endpunkte ermöglichen.

Was wurde geändert:

*   **`reporting/file_reporter.go`**:
    *   Die `types.Report`-Struktur wurde um das Feld `TopLongestRequests` vom Typ `[]types.RequestResult` erweitert.
    *   Die Funktionen `generateReportStreaming` und `enrichSummaryWithOfflineMetrics` wurden angepasst, um die Top 5 der längsten Requests zu berechnen und im `TopLongestRequests`-Feld des Reports zu speichern.  Die Requests werden anhand ihrer `ResponseTime` sortiert.
*   **`reporting/formatters/console/formatter_console.go`**:
    *   Die `Format`-Funktion wurde so angepasst, dass die Top 5 der längsten Requests in der Konsolenausgabe angezeigt werden.
*   **`reporting/formatters/hierarchical/hierarchical.go`**:
    *   Die Funktion `formatHierarchicalConsole` wurde so angepasst, dass die Top 5 der längsten Requests im hierarchischen Konsolenreport angezeigt werden.
    *   Die Funktion `formatHierarchicalJSON` wurde so angepasst, dass die TopLongestRequests in dem JSON Report ausgegeben werden.
*   **`reporting/formatters/hierarchical/templates/hierarchicalHTMLTemplate.html`**:
    *   Die HTML-Vorlage für den hierarchischen Report wurde aktualisiert, um die Top 5 der längsten Requests in einer Tabelle darzustellen.
*   **`reporting/formatters/html/templates/htmlTemplate.html`**:
    *   Die HTML-Vorlage wurde aktualisiert, um die Top 5 der längsten Requests in einer Tabelle anzuzeigen.
*   **`reporting/formatters/json/formatter_json.go`**:
    *   Die Funktion `Format` wurde angepasst, um die `TopLongestRequests` in den JSON-Report aufzunehmen.
*   **`reporting/types/types.go`**:
    *   Die `Report`-Struktur wurde um das Feld `TopLongestRequests` erweitert.

