### PR TITLE
fix: failed requests werden falsch angezeigt

### DIFF
--- a/reporting/file_reporter.go
+++ b/reporting/file_reporter.go
@@ -527,24 +527,24 @@ func (fr *FileReporter) updateGoroutineData(goroutines map[int]*goroutineData, r
 
 // buildSummaryFromData builds a summary report from collected data
 func (fr *FileReporter) buildSummaryFromData(summary *summaryData, startTime time.Time) types.Report {
-    report := types.Report{
-        TotalRequests:            summary.totalRequests,
-        SuccessfulRequests:       summary.successfulRequests,
-        FailedRequests:           summary.failedRequests,
-        MinResponseTime:          summary.minResponseTime,
-        MaxResponseTime:          summary.maxResponseTime,
-        ResponseTimeDistribution: summary.responseTimeDistribution,
-        ErrorBreakdown:           summary.errorBreakdown,
-        CheckSummaries:           summary.checkSummaries,
-        TotalChecks:              summary.totalChecks,
-        SuccessfulChecks:         summary.successfulChecks,
-        FailedChecks:             summary.failedChecks,
-        RequestDetails:           summary.requestDetails,
-        TopLongestRequests:       make([]types.RequestResult, 0),
-        StartTime:                startTime,
-        EndTime:                  time.Now(),
-        MetricsSummaries:         make(map[string]metrics.MetricSummary),
-    }
+	report := types.Report{
+		TotalRequests:            summary.totalRequests,
+		SuccessfulRequests:       summary.successfulRequests,
+		FailedRequests:           summary.failedRequests,
+		MinResponseTime:          summary.minResponseTime,
+		MaxResponseTime:          summary.maxResponseTime,
+		ResponseTimeDistribution: summary.responseTimeDistribution,
+		ErrorBreakdown:           summary.errorBreakdown,
+		CheckSummaries:           summary.checkSummaries,
+		TotalChecks:              summary.totalChecks,
+		SuccessfulChecks:         summary.successfulChecks,
+		FailedChecks:             summary.failedChecks,
+		RequestDetails:           summary.requestDetails,
+		TopLongestRequests:       make([]types.RequestResult, 0),
+		StartTime:                startTime,
+		EndTime:                  time.Now(),
+		MetricsSummaries:         make(map[string]metrics.MetricSummary),
+	}
 
 	// Calculate average response time
 	if report.TotalRequests > 0 {
@@ -557,9 +557,9 @@ func (fr *FileReporter) buildSummaryFromData(summary *summaryData, startTime tim
 // enrichSummaryWithOfflineMetrics computes Start/End/Runtime and key metric summaries
 // from the report's RequestDetails, for use when generating reports from raw results.
 func (fr *FileReporter) enrichSummaryWithOfflineMetrics(report *types.Report) {
-    if len(report.RequestDetails) == 0 {
-        return
-    }
+	if len(report.RequestDetails) == 0 {
+		return
+	}
 	// Infer start/end from timestamps if available
 	var firstTS time.Time
 	var lastTS time.Time
@@ -583,9 +583,9 @@ func (fr *FileReporter) enrichSummaryWithOfflineMetrics(report *types.Report) {
 		report.RuntimeSeconds = report.EndTime.Sub(report.StartTime).Seconds()
 	}
 
-    if report.MetricsSummaries == nil {
-        report.MetricsSummaries = make(map[string]metrics.MetricSummary)
-    }
+	if report.MetricsSummaries == nil {
+		report.MetricsSummaries = make(map[string]metrics.MetricSummary)
+	}
 
 	// http_reqs
 	if report.TotalRequests > 0 {
@@ -638,15 +638,15 @@ func (fr *FileReporter) enrichSummaryWithOfflineMetrics(report *types.Report) {
 	}
 
 	// checks
-    if report.TotalChecks > 0 {
-        report.MetricsSummaries["checks"] = metrics.MetricSummary{
-            Name:    "checks",
-            Type:    metrics.Rate,
-            Count:   report.TotalChecks,
-            Sum:     float64(report.SuccessfulChecks),
-            Average: float64(report.SuccessfulChecks) / float64(report.TotalChecks),
-        }
-    }
+	if report.TotalChecks > 0 {
+		report.MetricsSummaries["checks"] = metrics.MetricSummary{
+			Name:    "checks",
+			Type:    metrics.Rate,
+			Count:   report.TotalChecks,
+			Sum:     float64(report.SuccessfulChecks),
+			Average: float64(report.SuccessfulChecks) / float64(report.TotalChecks),
+		}
+	}
 
 	// Compute Top 5 Longest Requests by ResponseTime
 	if len(report.RequestDetails) > 0 {

--- a/reporting/formatters/console/formatter_console.go
+++ b/reporting/formatters/console/formatter_console.go
@@ -162,6 +162,11 @@ func (f *ConsoleFormatter) Format(report *types.Report) (string, error) {
 			buf.WriteString("Rates:\n")
 			for name, summary := range rates {
 				rate := summary.Average * 100 // Convert to percentage
+				// For http_req_failed, show number of failed requests (sum of 1/0 values)
+				if name == "http_req_failed" {
+					buf.WriteString(fmt.Sprintf("  %-25s %.2f%%  (count: %d)\n", name, rate, int(summary.Sum)))
+					continue
+				}
 				buf.WriteString(fmt.Sprintf("  %-25s %.2f%%  (count: %d)\n", name, rate, summary.Count))
 			}
 			buf.WriteString("\n")

--- a/reporting/formatters/hierarchical/hierarchical.go
+++ b/reporting/formatters/hierarchical/hierarchical.go
@@ -34,7 +34,7 @@ func (f *HierarchicalFormatter) FormatHierarchical(report *types.HierarchicalRep
 }
 
 func (f *HierarchicalFormatter) formatHierarchicalConsole(report *types.HierarchicalReport) (string, error) {
-    var buf bytes.Buffer
+	var buf bytes.Buffer
 
 	// Always show summary
 	buf.WriteString("HTTP Request Report - Summary\n")
@@ -57,27 +57,27 @@ func (f *HierarchicalFormatter) formatHierarchicalConsole(report *types.Hierarch
 		buf.WriteString(fmt.Sprintf("Request Success Rate: %.1f%%\n", successRate))
 	}
 
-    buf.WriteString(fmt.Sprintf("Average Response Time: %v\n", report.Summary.AverageResponseTime))
-    buf.WriteString(fmt.Sprintf("Total Duration: %v\n\n", report.Summary.EndTime.Sub(report.Summary.StartTime)))
+	buf.WriteString(fmt.Sprintf("Average Response Time: %v\n", report.Summary.AverageResponseTime))
+	buf.WriteString(fmt.Sprintf("Total Duration: %v\n\n", report.Summary.EndTime.Sub(report.Summary.StartTime)))
 
-    // Top longest requests (from summary)
-    if len(report.Summary.TopLongestRequests) > 0 {
-        buf.WriteString("Top 5 Longest Requests:\n")
-        limit := 5
-        if len(report.Summary.TopLongestRequests) < limit {
-            limit = len(report.Summary.TopLongestRequests)
-        }
-        for i := 0; i < limit; i++ {
-            req := report.Summary.TopLongestRequests[i]
-            status := fmt.Sprintf("%d ✓", req.StatusCode)
-            if !req.Success {
-                status = fmt.Sprintf("ERROR: %s", req.Error)
-            }
-            buf.WriteString(fmt.Sprintf("  %d. %s %s %s  %s  %.3f ms  (VU %d, Iter %d)\n",
-                i+1, req.Verb, req.Name, req.URL, status, float64(req.ResponseTime.Nanoseconds())/1e6, req.VirtualUserID, req.IterationID))
-        }
-        buf.WriteString("\n")
-    }
+	// Top longest requests (from summary)
+	if len(report.Summary.TopLongestRequests) > 0 {
+		buf.WriteString("Top 5 Longest Requests:\n")
+		limit := 5
+		if len(report.Summary.TopLongestRequests) < limit {
+			limit = len(report.Summary.TopLongestRequests)
+		}
+		for i := 0; i < limit; i++ {
+			req := report.Summary.TopLongestRequests[i]
+			status := fmt.Sprintf("%d ✓", req.StatusCode)
+			if !req.Success {
+				status = fmt.Sprintf("ERROR: %s", req.Error)
+			}
+			buf.WriteString(fmt.Sprintf("  %d. %s %s %s  %s  %.3f ms  (VU %d, Iter %d)\n",
+				i+1, req.Verb, req.Name, req.URL, status, float64(req.ResponseTime.Nanoseconds())/1e6, req.VirtualUserID, req.IterationID))
+		}
+		buf.WriteString("\n")
+	}
 
 	// Check results summary
 	if len(report.Summary.CheckSummaries) > 0 {
@@ -268,22 +268,22 @@ func (f *HierarchicalFormatter) formatHierarchicalConsole(report *types.Hierarch
 }
 
 func (f *HierarchicalFormatter) formatHierarchicalJSON(report *types.HierarchicalReport) (string, error) {
-    // Create structured JSON based on detail level
-    output := map[string]interface{}{
-        "summary": map[string]interface{}{
-            "totalGoroutines":      report.TotalVirtualUsers,
-            "successfulGoroutines": report.SuccessfulVirtualUsers,
-            "failedGoroutines":     report.FailedVirtualUsers,
-            "totalRequests":        report.Summary.TotalRequests,
-            "successfulRequests":   report.Summary.SuccessfulRequests,
-            "failedRequests":       report.Summary.FailedRequests,
-            "averageResponseTime":  report.Summary.AverageResponseTime.String(),
-            "totalDuration":        report.Summary.EndTime.Sub(report.Summary.StartTime).String(),
-            "startTime":            report.Summary.StartTime.Format(time.RFC3339),
-            "endTime":              report.Summary.EndTime.Format(time.RFC3339),
-            "topLongestRequests":   report.Summary.TopLongestRequests,
-        },
-    }
+	// Create structured JSON based on detail level
+	output := map[string]interface{}{
+		"summary": map[string]interface{}{
+			"totalGoroutines":      report.TotalVirtualUsers,
+			"successfulGoroutines": report.SuccessfulVirtualUsers,
+			"failedGoroutines":     report.FailedVirtualUsers,
+			"totalRequests":        report.Summary.TotalRequests,
+			"successfulRequests":   report.Summary.SuccessfulRequests,
+			"failedRequests":       report.Summary.FailedRequests,
+			"averageResponseTime":  report.Summary.AverageResponseTime.String(),
+			"totalDuration":        report.Summary.EndTime.Sub(report.Summary.StartTime).String(),
+			"startTime":            report.Summary.StartTime.Format(time.RFC3339),
+			"endTime":              report.Summary.EndTime.Format(time.RFC3339),
+			"topLongestRequests":   report.Summary.TopLongestRequests,
+		},
+	}
 
 	if f.DetailLevel == types.DetailVirtualuser || f.DetailLevel == types.DetailIteration || f.DetailLevel == types.DetailFull {
 		goroutines := make([]map[string]interface{}, 0, len(report.VirtualUserReports))

--- a/reporting/formatters/hierarchical/hierarchical.go
+++ b/reporting/formatters/hierarchical/hierarchical.go
@@ -155,6 +155,11 @@ func (f *HierarchicalFormatter) formatHierarchicalConsole(report *types.Hierarch
 			buf.WriteString("Rates:\n")
 			for name, summary := range rates {
 				rate := summary.Average * 100 // Convert to percentage
+				// For http_req_failed, show number of failed requests (sum of 1/0 values)
+				if name == "http_req_failed" {
+					buf.WriteString(fmt.Sprintf("  %-25s %.2f%%  (count: %d)\n", name, rate, int(summary.Sum)))
+					continue
+				}
 				buf.WriteString(fmt.Sprintf("  %-25s %.2f%%  (count: %d)\n", name, rate, summary.Count))
 			}
 			buf.WriteString("\n")

--- a/reporting/formatters/json/formatter_json.go
+++ b/reporting/formatters/json/formatter_json.go
@@ -11,36 +11,36 @@ import (
 type JSONFormatter struct{}
 
 func (f *JSONFormatter) Format(report *types.Report) (string, error) {
-    // Create a more structured JSON output
-    output := map[string]interface{}{
-        "summary": map[string]interface{}{
-            "totalRequests":       report.TotalRequests,
-            "successfulRequests":  report.SuccessfulRequests,
-            "failedRequests":      report.FailedRequests,
-            "successRate":         0.0,
-            "totalChecks":         report.TotalChecks,
-            "successfulChecks":    report.SuccessfulChecks,
-            "failedChecks":        report.FailedChecks,
-            "checkSuccessRate":    0.0,
-            "totalVirtualUsers":   report.TotalVirtualUsers,
-            "runtimeSeconds":      report.RuntimeSeconds,
-            "requestsPerSecond":   0.0,
-            "averageResponseTime": report.AverageResponseTime.String(),
-            "minResponseTime":     report.MinResponseTime.String(),
-            "maxResponseTime":     report.MaxResponseTime.String(),
-            "totalDuration":       report.EndTime.Sub(report.StartTime).String(),
-            "startTime":           report.StartTime.Format(time.RFC3339),
-            "endTime":             report.EndTime.Format(time.RFC3339),
-            "topLongestRequests":  report.TopLongestRequests,
-        },
-        "responseTimeDistribution": report.ResponseTimeDistribution,
-        "errorBreakdown":           report.ErrorBreakdown,
-        "checkSummaries":           report.CheckSummaries,
-        "metricsSummaries":         report.MetricsSummaries,
-        "perVUMetrics":             report.PerVUMetrics,
-        "perIterationMetrics":      report.PerIterationMetrics,
-        "requestDetails":           report.RequestDetails,
-    }
+	// Create a more structured JSON output
+	output := map[string]interface{}{
+		"summary": map[string]interface{}{
+			"totalRequests":       report.TotalRequests,
+			"successfulRequests":  report.SuccessfulRequests,
+			"failedRequests":      report.FailedRequests,
+			"successRate":         0.0,
+			"totalChecks":         report.TotalChecks,
+			"successfulChecks":    report.SuccessfulChecks,
+			"failedChecks":        report.FailedChecks,
+			"checkSuccessRate":    0.0,
+			"totalVirtualUsers":   report.TotalVirtualUsers,
+			"runtimeSeconds":      report.RuntimeSeconds,
+			"requestsPerSecond":   0.0,
+			"averageResponseTime": report.AverageResponseTime.String(),
+			"minResponseTime":     report.MinResponseTime.String(),
+			"maxResponseTime":     report.MaxResponseTime.String(),
+			"totalDuration":       report.EndTime.Sub(report.StartTime).String(),
+			"startTime":           report.StartTime.Format(time.RFC3339),
+			"endTime":             report.EndTime.Format(time.RFC3339),
+			"topLongestRequests":  report.TopLongestRequests,
+		},
+		"responseTimeDistribution": report.ResponseTimeDistribution,
+		"errorBreakdown":           report.ErrorBreakdown,
+		"checkSummaries":           report.CheckSummaries,
+		"metricsSummaries":         report.MetricsSummaries,
+		"perVUMetrics":             report.PerVUMetrics,
+		"perIterationMetrics":      report.PerIterationMetrics,
+		"requestDetails":           report.RequestDetails,
+	}
 
 	if report.TotalRequests > 0 {
 		output["summary"].(map[string]interface{})["successRate"] = float64(report.SuccessfulRequests) / float64(report.TotalRequests) * 100

--- a/reporting/types/types.go
+++ b/reporting/types/types.go
@@ -40,29 +40,29 @@ type RequestResult struct {
 
 // Report contains aggregated statistics from all request executions
 type Report struct {
-    TotalRequests            int
-    SuccessfulRequests       int
-    FailedRequests           int
-    AverageResponseTime      time.Duration
-    MinResponseTime          time.Duration
-    MaxResponseTime          time.Duration
-    ResponseTimeDistribution map[string]int
-    ErrorBreakdown           map[string]int
-    RequestDetails           []RequestResult
-    // TopLongestRequests contains the top N requests by ResponseTime (descending)
-    // This helps identify the longest-running calls quickly in reports.
-    TopLongestRequests       []RequestResult
-    StartTime                time.Time
-    EndTime                  time.Time
-    CheckSummaries           map[string]CheckSummary
-    TotalChecks              int
-    SuccessfulChecks         int
-	FailedChecks             int
-	MetricsSummaries         map[string]metrics.MetricSummary
-	TotalVirtualUsers        int
-	RuntimeSeconds           float64
-	PerVUMetrics             map[string]float64
-	PerIterationMetrics      map[string]float64
+	TotalRequests            int
+	SuccessfulRequests       int
+	FailedRequests           int
+	AverageResponseTime      time.Duration
+	MinResponseTime          time.Duration
+	MaxResponseTime          time.Duration
+	ResponseTimeDistribution map[string]int
+	ErrorBreakdown           map[string]int
+	RequestDetails           []RequestResult
+	// TopLongestRequests contains the top N requests by ResponseTime (descending)
+	// This helps identify the longest-running calls quickly in reports.
+	TopLongestRequests  []RequestResult
+	StartTime           time.Time
+	EndTime             time.Time
+	CheckSummaries      map[string]CheckSummary
+	TotalChecks         int
+	SuccessfulChecks    int
+	FailedChecks        int
+	MetricsSummaries    map[string]metrics.MetricSummary
+	TotalVirtualUsers   int
+	RuntimeSeconds      float64
+	PerVUMetrics        map[string]float64
+	PerIterationMetrics map[string]float64
 }
 
 // IterationReport contains results for a single iteration


### PR DESCRIPTION
Beschreibung:
Die Ausgabe der Metrik `http_req_failed` in den Konsolen-Reportformatierern wurde verbessert, um die Anzahl der fehlgeschlagenen Requests anstelle der Anzahl der Messungen anzuzeigen.

Motivation:
Bisher wurde für die Metrik `http_req_failed` die Anzahl der Messungen (Count) ausgegeben, was irreführend war, da diese Metrik binär ist (1 für fehlgeschlagen, 0 für erfolgreich).  Es ist sinnvoller, die tatsächliche Anzahl der fehlgeschlagenen Requests anzuzeigen, um ein klareres Bild der Fehlerquote zu erhalten.

Was wurde geändert:
- `reporting/formatters/console/formatter_console.go`:  Die Formatierung der `http_req_failed` Metrik wurde angepasst, sodass die Summe der Werte (Anzahl der fehlgeschlagenen Requests) anstelle der Anzahl der Messungen ausgegeben wird.
- `reporting/formatters/hierarchical/hierarchical.go`:  Die Formatierung der `http_req_failed` Metrik wurde angepasst, sodass die Summe der Werte (Anzahl der fehlgeschlagenen Requests) anstelle der Anzahl der Messungen ausgegeben wird.

Tests:
Es wurden keine neuen Tests geschrieben oder bestehende Tests angepasst.

**WARNUNG:** Da keine Tests existieren, die die korrekte Formatierung der Konsolenausgabe verifizieren, sollte diese Änderung manuell getestet werden, um sicherzustellen, dass die Ausgabe wie erwartet funktioniert. Es wäre ratsam, in Zukunft automatisierte Tests für diese Art von Formatierungsänderungen hinzuzufügen, um Regressionen zu vermeiden.

