### PR TITLE
feat: Export raw results into csv format

### DIFF
--- a/cmd/httprunner/main.go
+++ b/cmd/httprunner/main.go
@@ -19,9 +19,9 @@ import (
 var version = "dev"
 
 func main() {
-	// Command line flags
-	showVersion := flag.Bool("version", false, "Print version and exit")
-	flag.BoolVar(showVersion, "V", false, "Print version and exit")
+    // Command line flags
+    showVersion := flag.Bool("version", false, "Print version and exit")
+    flag.BoolVar(showVersion, "V", false, "Print version and exit")
 	concurrency := flag.Int("u", 1, "Number of parallel virtual parallel users")
 	iterations := flag.Int("i", 1, "Number of iterations")
 	runtime := flag.Int("r", 0, "Runtime duration in seconds (0 means use iterations)")
@@ -29,11 +29,12 @@ func main() {
 	offset := flag.Int("offset", 0, "Max random startup delay per VU in milliseconds")
 	requestFile := flag.String("f", "", ".http file containing http requests")
 	envFile := flag.String("e", "", ".env file containing environment variables")
-	reportFormat := flag.String("report", "console", "Report format: console, html, csv, json")
-	reportOutput := flag.String("output", "results", "Output directory for results and reports")
-	reportDetail := flag.String("detail", "summary", "Report detail level: summary, goroutine, iteration, full")
-	verbose := flag.Bool("v", false, "Verbose mode: print request result JSON for each request")
-	rawFile := flag.String("raw", "", "Path to raw results .jsonl file to generate report without executing")
+    reportFormat := flag.String("report", "console", "Report format: console, html, csv, json")
+    reportOutput := flag.String("output", "results", "Output directory for results and reports")
+    reportDetail := flag.String("detail", "summary", "Report detail level: summary, goroutine, iteration, full")
+    verbose := flag.Bool("v", false, "Verbose mode: print request result JSON for each request")
+    rawFile := flag.String("raw", "", "Path to raw results .jsonl file to generate report without executing")
+    csvShortcut := flag.Bool("csv", false, "Shorthand to output CSV from -raw to stdout (forces -report=csv, -detail=summary)")
 
 	flag.Parse()
 
@@ -42,12 +43,25 @@ func main() {
 		return
 	}
 
-	// Offline reporting mode: when -raw is provided, skip execution
-	offlineMode := *rawFile != ""
-	if !offlineMode && *requestFile == "" {
-		fmt.Println("Error: -f flag is required (or provide -raw to read a raw results file)")
-		os.Exit(1)
-	}
+    // Offline reporting mode: when -raw is provided, skip execution
+    offlineMode := *rawFile != ""
+    if !offlineMode && *requestFile == "" {
+        fmt.Println("Error: -f flag is required (or provide -raw to read a raw results file)")
+        os.Exit(1)
+    }
+
+    // If -csv shorthand is provided, force CSV formatting and summary detail;
+    // also prefer printing to stdout for easy redirection.
+    forceStdout := false
+    if *csvShortcut {
+        *reportFormat = string(types.FormatCSV)
+        *reportDetail = string(types.DetailSummary)
+        forceStdout = true
+        if !offlineMode {
+            fmt.Println("Error: -csv requires -raw to be provided")
+            os.Exit(1)
+        }
+    }
 
 	// Validate runtime vs iterations parameters (only for execution mode)
 	if !offlineMode {
@@ -81,10 +95,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	// If offline mode, build report from raw file and exit
-	if offlineMode {
-		// Build a FileReporter on the provided raw file
-		fr := reporting.NewFileReporter(*rawFile)
+    // If offline mode, build report from raw file and exit
+    if offlineMode {
+        // Build a FileReporter on the provided raw file
+        fr := reporting.NewFileReporter(*rawFile)
 
 		var reportContent string
 		var err error
@@ -115,14 +129,14 @@ func main() {
 			os.Exit(1)
 		}
 
-		// Output handling mirrors execution mode
-		format := types.ReportFormat(strings.ToLower(*reportFormat))
-		if format == types.FormatConsole {
-			fmt.Print(reportContent)
-		} else {
-			// Ensure output directory exists
-			if err := os.MkdirAll(*reportOutput, 0755); err != nil {
-				fmt.Printf("Error ensuring output directory: %v\n", err)
+        // Output handling mirrors execution mode
+        format := types.ReportFormat(strings.ToLower(*reportFormat))
+        if format == types.FormatConsole || forceStdout {
+            fmt.Print(reportContent)
+        } else {
+            // Ensure output directory exists
+            if err := os.MkdirAll(*reportOutput, 0755); err != nil {
+                fmt.Printf("Error ensuring output directory: %v\n", err)
 				os.Exit(1)
 			}
 			filename := filepath.Join(*reportOutput, "report")

--- a/cmd/httprunner/main.go
+++ b/cmd/httprunner/main.go
@@ -19,9 +19,9 @@ import (
 var version = "dev"
 
 func main() {
-    // Command line flags
-    showVersion := flag.Bool("version", false, "Print version and exit")
-    flag.BoolVar(showVersion, "V", false, "Print version and exit")
+	// Command line flags
+	showVersion := flag.Bool("version", false, "Print version and exit")
+	flag.BoolVar(showVersion, "V", false, "Print version and exit")
 	concurrency := flag.Int("u", 1, "Number of parallel virtual parallel users")
 	iterations := flag.Int("i", 1, "Number of iterations")
 	runtime := flag.Int("r", 0, "Runtime duration in seconds (0 means use iterations)")
@@ -29,12 +29,12 @@ func main() {
 	offset := flag.Int("offset", 0, "Max random startup delay per VU in milliseconds")
 	requestFile := flag.String("f", "", ".http file containing http requests")
 	envFile := flag.String("e", "", ".env file containing environment variables")
-    reportFormat := flag.String("report", "console", "Report format: console, html, csv, json")
-    reportOutput := flag.String("output", "results", "Output directory for results and reports")
-    reportDetail := flag.String("detail", "summary", "Report detail level: summary, goroutine, iteration, full")
-    verbose := flag.Bool("v", false, "Verbose mode: print request result JSON for each request")
-    rawFile := flag.String("raw", "", "Path to raw results .jsonl file to generate report without executing")
-    csvShortcut := flag.Bool("csv", false, "Shorthand to output CSV from -raw to stdout (forces -report=csv, -detail=summary)")
+	reportFormat := flag.String("report", "console", "Report format: console, html, csv, json")
+	reportOutput := flag.String("output", "results", "Output directory for results and reports")
+	reportDetail := flag.String("detail", "summary", "Report detail level: summary, goroutine, iteration, full")
+	verbose := flag.Bool("v", false, "Verbose mode: print request result JSON for each request")
+	rawFile := flag.String("raw", "", "Path to raw results .jsonl file to generate report without executing")
+	csvShortcut := flag.Bool("csv", false, "Shorthand to output CSV from -raw to stdout (forces -report=csv, -detail=summary)")
 
 	flag.Parse()
 
@@ -43,25 +43,25 @@ func main() {
 		return
 	}
 
-    // Offline reporting mode: when -raw is provided, skip execution
-    offlineMode := *rawFile != ""
-    if !offlineMode && *requestFile == "" {
-        fmt.Println("Error: -f flag is required (or provide -raw to read a raw results file)")
-        os.Exit(1)
-    }
+	// Offline reporting mode: when -raw is provided, skip execution
+	offlineMode := *rawFile != ""
+	if !offlineMode && *requestFile == "" {
+		fmt.Println("Error: -f flag is required (or provide -raw to read a raw results file)")
+		os.Exit(1)
+	}
 
-    // If -csv shorthand is provided, force CSV formatting and summary detail;
-    // also prefer printing to stdout for easy redirection.
-    forceStdout := false
-    if *csvShortcut {
-        *reportFormat = string(types.FormatCSV)
-        *reportDetail = string(types.DetailSummary)
-        forceStdout = true
-        if !offlineMode {
-            fmt.Println("Error: -csv requires -raw to be provided")
-            os.Exit(1)
-        }
-    }
+	// If -csv shorthand is provided, force CSV formatting and summary detail;
+	// also prefer printing to stdout for easy redirection.
+	forceStdout := false
+	if *csvShortcut {
+		*reportFormat = string(types.FormatCSV)
+		*reportDetail = string(types.DetailSummary)
+		forceStdout = true
+		if !offlineMode {
+			fmt.Println("Error: -csv requires -raw to be provided")
+			os.Exit(1)
+		}
+	}
 
 	// Validate runtime vs iterations parameters (only for execution mode)
 	if !offlineMode {
@@ -95,10 +95,10 @@ func main() {
 		os.Exit(1)
 	}
 
-    // If offline mode, build report from raw file and exit
-    if offlineMode {
-        // Build a FileReporter on the provided raw file
-        fr := reporting.NewFileReporter(*rawFile)
+	// If offline mode, build report from raw file and exit
+	if offlineMode {
+		// Build a FileReporter on the provided raw file
+		fr := reporting.NewFileReporter(*rawFile)
 
 		var reportContent string
 		var err error
@@ -129,14 +129,14 @@ func main() {
 			os.Exit(1)
 		}
 
-        // Output handling mirrors execution mode
-        format := types.ReportFormat(strings.ToLower(*reportFormat))
-        if format == types.FormatConsole || forceStdout {
-            fmt.Print(reportContent)
-        } else {
-            // Ensure output directory exists
-            if err := os.MkdirAll(*reportOutput, 0755); err != nil {
-                fmt.Printf("Error ensuring output directory: %v\n", err)
+		// Output handling mirrors execution mode
+		format := types.ReportFormat(strings.ToLower(*reportFormat))
+		if format == types.FormatConsole || forceStdout {
+			fmt.Print(reportContent)
+		} else {
+			// Ensure output directory exists
+			if err := os.MkdirAll(*reportOutput, 0755); err != nil {
+				fmt.Printf("Error ensuring output directory: %v\n", err)
 				os.Exit(1)
 			}
 			filename := filepath.Join(*reportOutput, "report")

--- a/cmd/httprunner/main_test.go
+++ b/cmd/httprunner/main_test.go
@@ -150,3 +150,31 @@ func TestRunnerExitsOnInvalidDetailLevel(t *testing.T) {
 		t.Fatalf("expected invalid detail message; got: %s", string(out))
 	}
 }
+
+func TestOfflineCSVShortcutPrintsToStdout(t *testing.T) {
+    dir := t.TempDir()
+    // Write minimal JSONL with a single RequestResult
+    jsonl := `{"Name":"Req1","Verb":"GET","URL":"http://example.com","StatusCode":200,"ResponseTime":100000000,"Success":true,"Error":"","Timestamp":"2024-01-01T00:00:00Z","VirtualUserID":1,"IterationID":1,"Checks":[]}`
+    p := filepath.Join(dir, "results.jsonl")
+    if err := os.WriteFile(p, []byte(jsonl+"\n"), 0644); err != nil {
+        t.Fatalf("write jsonl: %v", err)
+    }
+
+    // Isolate flags
+    oldFS := flag.CommandLine
+    flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+    flag.CommandLine.SetOutput(new(strings.Builder))
+    defer func() { flag.CommandLine = oldFS }()
+
+    oldArgs := os.Args
+    os.Args = []string{"httprunner", "-raw", p, "-csv"}
+    defer func() { os.Args = oldArgs }()
+
+    out := captureStdout(func() { main() })
+    if !strings.Contains(out, "Index,Name,Method,URL,Success,StatusCode,ResponseTime,Error,CheckFailures,Timestamp") {
+        t.Fatalf("expected CSV header in output; got:\n%s", out)
+    }
+    if !strings.Contains(out, "Req1") {
+        t.Fatalf("expected CSV row with request name; got:\n%s", out)
+    }
+}

--- a/cmd/httprunner/main_test.go
+++ b/cmd/httprunner/main_test.go
@@ -152,29 +152,29 @@ func TestRunnerExitsOnInvalidDetailLevel(t *testing.T) {
 }
 
 func TestOfflineCSVShortcutPrintsToStdout(t *testing.T) {
-    dir := t.TempDir()
-    // Write minimal JSONL with a single RequestResult
-    jsonl := `{"Name":"Req1","Verb":"GET","URL":"http://example.com","StatusCode":200,"ResponseTime":100000000,"Success":true,"Error":"","Timestamp":"2024-01-01T00:00:00Z","VirtualUserID":1,"IterationID":1,"Checks":[]}`
-    p := filepath.Join(dir, "results.jsonl")
-    if err := os.WriteFile(p, []byte(jsonl+"\n"), 0644); err != nil {
-        t.Fatalf("write jsonl: %v", err)
-    }
+	dir := t.TempDir()
+	// Write minimal JSONL with a single RequestResult
+	jsonl := `{"Name":"Req1","Verb":"GET","URL":"http://example.com","StatusCode":200,"ResponseTime":100000000,"Success":true,"Error":"","Timestamp":"2024-01-01T00:00:00Z","VirtualUserID":1,"IterationID":1,"Checks":[]}`
+	p := filepath.Join(dir, "results.jsonl")
+	if err := os.WriteFile(p, []byte(jsonl+"\n"), 0644); err != nil {
+		t.Fatalf("write jsonl: %v", err)
+	}
 
-    // Isolate flags
-    oldFS := flag.CommandLine
-    flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
-    flag.CommandLine.SetOutput(new(strings.Builder))
-    defer func() { flag.CommandLine = oldFS }()
+	// Isolate flags
+	oldFS := flag.CommandLine
+	flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+	flag.CommandLine.SetOutput(new(strings.Builder))
+	defer func() { flag.CommandLine = oldFS }()
 
-    oldArgs := os.Args
-    os.Args = []string{"httprunner", "-raw", p, "-csv"}
-    defer func() { os.Args = oldArgs }()
+	oldArgs := os.Args
+	os.Args = []string{"httprunner", "-raw", p, "-csv"}
+	defer func() { os.Args = oldArgs }()
 
-    out := captureStdout(func() { main() })
-    if !strings.Contains(out, "Index,Name,Method,URL,Success,StatusCode,ResponseTime,Error,CheckFailures,Timestamp") {
-        t.Fatalf("expected CSV header in output; got:\n%s", out)
-    }
-    if !strings.Contains(out, "Req1") {
-        t.Fatalf("expected CSV row with request name; got:\n%s", out)
-    }
+	out := captureStdout(func() { main() })
+	if !strings.Contains(out, "Index,Name,Method,URL,Success,StatusCode,ResponseTime,Error,CheckFailures,Timestamp") {
+		t.Fatalf("expected CSV header in output; got:\n%s", out)
+	}
+	if !strings.Contains(out, "Req1") {
+		t.Fatalf("expected CSV row with request name; got:\n%s", out)
+	}
 }


### PR DESCRIPTION
Description:
Adds a shortcut flag `-csv` to output CSV reports directly to stdout when using the `-raw` option for offline reporting.

Motivation:
The existing `-raw` reporting functionality allows generating reports from raw result files. However, outputting CSV reports required specifying the `-report` and `-output` flags, creating a file on disk.  This change simplifies the process of generating and viewing CSV reports directly in the terminal, especially useful for quick analysis and scripting.

What was changed:
- Modified `cmd/httprunner/main.go` to add the `-csv` flag.
- When the `-csv` flag is present, it forces `-report=csv` and `-detail=summary`, and outputs to stdout
- Added a check to ensure -csv is used together with -raw, exiting with an error otherwise

Tests:
- Added a new test case `TestOfflineCSVShortcutPrintsToStdout` in `cmd/httprunner/main_test.go` to verify the new functionality. This test creates a temporary results file, executes the runner with the `-raw` and `-csv` flags, and asserts that the CSV output is printed to stdout and contains the expected data.
